### PR TITLE
Add support for unprivileged containerized builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ environment vars to be set:
   `gihub_pull_id`).
 - `github_pull_id` -- Pull request ID to test (incompatible
   with `github_branch`).
-- `os_keyname` -- OpenStack keypair to use for provisioning.
-- `os_network` -- OpenStack network to use for provisioning.
 
 The following optional environment vars may be set:
 
@@ -35,6 +33,10 @@ The following optional environment vars may be set:
   for handling of race conditions.
 - `github_token` -- If specified, update the commit status
   using GitHub's API, accessed with this repo-scoped token.
+- `os_keyname` -- OpenStack keypair to use for provisioning,
+  if you want to support virtualized tests.
+- `os_network` -- OpenStack network to use for provisioning,
+  if you want to support virtualized tests.
 - `os_floating_ip_pool` -- If specified, assign a floating
   IP to the provisioned node from this pool and use the IP
   to communicate with it. This is required if not running on
@@ -42,9 +44,10 @@ The following optional environment vars may be set:
 - `s3_prefix` -- If specified, artifacts will be uploaded to
   this S3 path, in `<bucket>[/<prefix>]` form.
 
-It also implicitly expects the usual OpenStack variables
-needed for authentication. These can normally be sourced
-from an RC file downloadable from the OpenStack interface:
+If you want to support virtualized tests, it also implicitly
+expects the usual OpenStack variables needed for
+authentication. These can normally be sourced from an RC
+file downloadable from the OpenStack interface:
 
 - `OS_AUTH_URL`
 - `OS_TENANT_ID`
@@ -64,11 +67,13 @@ can be run locally, which is useful for testing. The easiest
 way to get started is to run inside a Python virtualenv with
 the python-novaclient and awscli packages installed (the
 latter only being required if artifact uploading is wanted).
+Docker is also expected to be up and running for
+containerized tests.
 
 The script checks out the repo in `checkouts/$repo` and will
 re-use it if available rather than cloning each time. No
 builds are done on the host; the repo is transferred to the
-test node during provisioning.
+test environment during provisioning.
 
 A `state` directory is created, in which all temporary
 files that need to be stored during a run are kept.

--- a/main
+++ b/main
@@ -41,11 +41,7 @@ main() {
         fi
     fi
 
-    # Before we even provision, let's make sure we will
-    # teardown at exit time.
-    ensure_teardown_node
-
-    provision_node
+    provision_env
 
     run_tests
 
@@ -123,8 +119,24 @@ parse_yml() {
 
     if ! $THIS_DIR/utils/yml-parser.py state/parsed \
             checkouts/$github_repo/.redhat-ci.yml; then
-        update_github failure "ERROR: Invalid .redhat-ci.yml"
+        update_github failure "ERROR: Invalid .redhat-ci.yml file."
         exit 0
+    fi
+}
+
+provision_env() {
+
+    if containerized; then
+
+        provision_container
+
+    else
+
+        # Before we even provision, let's make sure we will
+        # teardown at exit time.
+        ensure_teardown_node
+
+        provision_node
     fi
 }
 
@@ -136,8 +148,8 @@ provision_node() {
     update_github pending "Provisioning test node."
 
     # XXX: We hardcode m1.small for now, but these really
-    # should bespecified indirectly from the .redhat-ci YAML
-    # file through e.g. min-* vars.
+    # should be specified indirectly from the .redhat-ci
+    # YAML file through e.g. min-* vars.
     env \
         os_image="$image" \
         os_flavor=m1.small \
@@ -149,9 +161,12 @@ provision_node() {
 
     push_repo
 
-    push_worker_script
-
     inject_yum_repos
+
+    gen_worker_script
+
+    # push it out to the node
+    vmscp state/worker.sh root@$(cat state/node_addr):/root
 }
 
 vmssh() {
@@ -182,8 +197,37 @@ ssh_wait() {
         sleep 1
     done
 
-    # do a final test and let it fail if it's still not done
-    vmssh true
+    # do a final test on timeout
+    if ! vmssh true; then
+        echo "ERROR: Timed out while waiting for SSH."
+    fi
+}
+
+provision_container() {
+    local image=$(cat state/parsed/image)
+
+    # Let's pre-pull the image so that it doesn't count
+    # as part of the test timeout.
+    if docker pull "$image"; then
+        update_github failure "ERROR: Could not pull image '$image'."
+        exit 0
+    fi
+
+    # Everything that will be bind-mounted goes there.
+    mkdir state/cnt
+
+    cp -a checkouts/$github_repo state/cnt/checkout
+
+    # let's just make it always exist so we don't have to
+    # use eval during docker run
+    touch state/cnt/rhci-extras.repo
+    if [ -f state/parsed/rhci-extras.repo ]; then
+        cp state/parsed/rhci-extras.repo state/cnt
+    fi
+
+    gen_worker_script
+
+    cp state/worker.sh state/cnt
 }
 
 push_repo() {
@@ -196,8 +240,7 @@ push_repo() {
         checkouts/$github_repo/ root@$node_addr:/root/checkout/
 }
 
-push_worker_script() {
-    local node_addr=$(cat state/node_addr)
+gen_worker_script() {
 
     # let's build the worker script that will be executed on the node
     touch state/worker.sh
@@ -215,21 +258,20 @@ push_worker_script() {
     fi
 
     append cd checkout
+
     append "$(cat state/parsed/tests)"
 
     unset -f append
-
-    vmscp state/worker.sh root@$node_addr:/root
 }
 
 inject_yum_repos() {
     local node_addr=$(cat state/node_addr)
 
-    if [ ! -f state/parsed/extras.repo ]; then
+    if [ ! -f state/parsed/rhci-extras.repo ]; then
         return 0
     fi
 
-    vmscp state/parsed/extras.repo root@$node_addr:/etc/yum.repos.d
+    vmscp state/parsed/rhci-extras.repo root@$node_addr:/etc/yum.repos.d
 }
 
 run_tests() {
@@ -262,11 +304,39 @@ run_tests() {
 
     local rc=0
     local timeout=$(cat state/parsed/timeout)
-    timeout --kill-after=30s $timeout \
-        ssh -q -o StrictHostKeyChecking=no \
-               -o UserKnownHostsFile=/dev/null \
-               root@$node_addr "sh worker.sh 2>&1" | \
-        tee -a $upload_dir/output.txt || rc=$?
+
+    if ! containerized; then
+        timeout --kill-after=30s "$timeout" \
+            ssh -q -o StrictHostKeyChecking=no \
+                   -o UserKnownHostsFile=/dev/null \
+                   root@$node_addr "sh worker.sh 2>&1" | \
+            tee -a $upload_dir/output.txt || rc=$?
+    else
+        local mnt=$PWD/state/cnt
+
+        # We use below to make it more convenient for running unprivileged on
+        # dev machines. Though because we use timeout, sudo doesn't have control
+        # of the TTY, so we use it beforehand so it can cache credentials.
+        sudo true
+
+        # Setting a timeout on docker run is not reliable since it's the daemon
+        # running it. And we don't want to trust the timeout *inside* the
+        # container as well. So we follow up with a docker kill.
+        timeout --kill-after=30s "$timeout" \
+            sudo docker run --rm \
+                --workdir / \
+                --cidfile state/cid \
+                -v $mnt/checkout:/checkout:z \
+                -v $mnt/worker.sh:/worker.sh:z \
+                -v $mnt/rhci-extras.repo:/etc/yum.repos.d/rhci-extras.repo:z \
+                "$(cat state/parsed/image)" sh -c "sh worker.sh 2>&1" | \
+            tee -a $upload_dir/output.txt || rc=$?
+        if [ -f state/cid ]; then
+            # kill if it's not already dead
+            sudo docker kill $(cat state/cid) || :
+        fi
+    fi
+
     echo "$rc" > state/rc
 }
 
@@ -276,27 +346,41 @@ prep_artifacts() {
 
     # let's pull back the artifacts
     if [ -f state/parsed/artifacts ]; then
-        mkdir $upload_dir/artifacts
-
-        # So apparently the rsync in RHEL/Centos 7 is too
-        # old to have --ignore-missing-args, which would be
-        # really handy here. Fun/sad fact: that feature has
-        # been upstream since *2009*. Wow.
-
-        #rsync -raz --quiet --delete-missing-args --no-owner --no-group \
-        #    -e "ssh -q -o StrictHostKeyChecking=no \
-        #               -o PasswordAuthentication=no \
-        #               -o UserKnownHostsFile=/dev/null" \
-        #    --files-from=state/parsed/artifacts \
-        #    root@$node_addr:checkout $upload_dir/artifacts/
 
         # use a variable instead or `read` misses the last non-newline
         # terminated line
         local artifacts=$(cat state/parsed/artifacts)
-        while read artifact; do
-            vmscp -r root@$node_addr:checkout/$artifact \
-                $upload_dir/artifacts || :
-        done <<< "$artifacts"
+
+        mkdir $upload_dir/artifacts
+
+        if ! containerized; then
+
+            # So apparently the rsync in RHEL/Centos 7 is too
+            # old to have --ignore-missing-args, which would be
+            # really handy here. Fun/sad fact: that feature has
+            # been upstream since *2009*. Wow.
+
+            #rsync -raz --quiet --delete-missing-args --no-owner --no-group \
+            #    -e "ssh -q -o StrictHostKeyChecking=no \
+            #               -o PasswordAuthentication=no \
+            #               -o UserKnownHostsFile=/dev/null" \
+            #    --files-from=state/parsed/artifacts \
+            #    root@$node_addr:checkout $upload_dir/artifacts/
+
+            while read artifact; do
+                vmscp -r "root@$node_addr:checkout/$artifact" \
+                    $upload_dir/artifacts || :
+            done <<< "$artifacts"
+        else
+            # NB: we ran as root, so chown in case we're unprivileged
+            while read artifact; do
+                path="state/cnt/checkout/$artifact"
+                if sudo [ -e "$path" ]; then
+                    sudo chown -R $UID:$UID $path
+                    cp -r $path $upload_dir/artifacts
+                fi
+            done <<< "$artifacts"
+        fi
 
         local indexer=$(realpath $THIS_DIR/utils/indexer.py)
         pushd $upload_dir
@@ -375,6 +459,10 @@ teardown_node() {
 
 ensure_teardown_node() {
     trap teardown_node EXIT
+}
+
+containerized() {
+    [ -f state/parsed/image ]
 }
 
 # Send a commit status update to GitHub

--- a/main
+++ b/main
@@ -61,7 +61,7 @@ validate_vars() {
     else
         # let's not print token information
         set +x
-        for var in github_{repo,token} os_{keyname,network}; do
+        for var in github_{repo,token}; do
             if [ -z "${!var:-}" ]; then
                 echo "ERROR: Missing variable '${var}'."
                 return 1

--- a/main
+++ b/main
@@ -189,6 +189,14 @@ ssh_wait() {
 
     timeout 60s "$THIS_DIR/utils/sshwait" $node_addr
 
+    # XXX: The timeout method below will fail on rare
+    # occasions in strange ways (the vmssh in the loop
+    # condition works, but the the follow-up one in the
+    # final test doesn't). Seems like it might be a blip in
+    # OpenStack. If this happens often, we might need to
+    # strengthen this to require e.g. $x secs of continuous
+    # `vmssh true`.
+
     # SSH may be ready, but cloud-init might not have
     # finished injecting the key yet.
     max_sleep=30

--- a/sample.redhat-ci.yml
+++ b/sample.redhat-ci.yml
@@ -3,18 +3,24 @@
 # maintain backwards compatibility (or help projects migrate
 # to the new format).
 
-# REQUIRED
+# REQUIRED (one of 'host' or 'container')
 # All details about the host to provision go under the host
 # key, though for now, 'distro' is the only handled child:
 host:
     # REQUIRED
     # Specify the distro to provision. More options will be
     # added, but currently available are:
-    #   fedora/24/cloud
-    #   fedora/24/atomic
-    #   centos/7/cloud
-    #   centos/7/atomic
+    #   - fedora/24/cloud
+    #   - fedora/24/atomic
+    #   - centos/7/cloud
+    #   - centos/7/atomic
     distro: fedora/24/cloud
+
+# REQUIRED (one of 'host' or 'container')
+container:
+    # REQUIRED
+    # Specify an FQIN or Docker Hub image.
+    image: fedora:24
 
 # OPTIONAL
 # List the branches to test. If omitted, only the master

--- a/utils/yml-parser.py
+++ b/utils/yml-parser.py
@@ -19,19 +19,27 @@ def write_to_file(fn, s):
     with open(os.path.join(output_dir, fn), 'w') as f:
         f.write(s);
 
-if 'host' not in yml:
-    print("ERROR: Missing 'host' entry in YAML.")
+# Let's validate before writing any files.
+
+if 'host' in yml and 'container' in yml:
+    print("ERROR: Cannot have both 'host' and 'container' entries in YAML.")
+    exit(1)
+elif 'host' in yml:
+    if 'distro' not in yml['host']:
+        print("ERROR: Missing 'distro' entry from 'host' in YAML.")
+        exit(1)
+elif 'container' in yml:
+    if 'image' not in yml['container']:
+        print("ERROR: Missing 'image' entry from 'container' in YAML.")
+        exit(1)
+else:
+    print("ERROR: Missing both 'host' and 'container' entries in YAML.")
     exit(1)
 
-if 'distro' not in yml['host']:
-    print("ERROR: Missing 'distro' entry from 'host' in YAML.")
-    exit(1)
-
-if 'tests' not in yml:
-    print("ERROR: Missing 'tests' entry in YAML.")
-    exit(1)
-
-write_to_file("distro", yml['host']['distro'])
+if 'host' in yml:
+    write_to_file("distro", yml['host']['distro'])
+if 'container' in yml:
+    write_to_file("image", yml['container']['image'])
 write_to_file("tests", '\n'.join(yml['tests']))
 write_to_file("branches", '\n'.join(yml.get('branches', ['master'])))
 write_to_file("timeout", yml.get('timeout','2h'))
@@ -44,7 +52,7 @@ if 'extra-repos' in yml:
         for key, val in repo.iteritems():
             repos += "%s=%s\n" % (key, val)
     if repos != "":
-        write_to_file("extras.repo", repos)
+        write_to_file("rhci-extras.repo", repos)
 
 if 'packages' in yml:
     write_to_file("packages", ' '.join(yml['packages']))


### PR DESCRIPTION
Add a new `container` key in the spec that will allow users to run directly in a Docker container on the executing node (i.e. the node that runs `main`).

---

Of course, the next step here on the backend is to wrap this all up in a Dockerfile and migrate the executor to an Atomic Host.
