### PR TITLE
sample: Use https for repos

### DIFF
--- a/sample.redhat-ci.yml
+++ b/sample.redhat-ci.yml
@@ -63,10 +63,9 @@ context: 'CI Tester'
 # Additional YUM repositories to inject during provisioning.
 extra-repos:
     - name: my-repo-name # REQUIRED key
-      baseurl: http://example.com/repo
-      gpgcheck: 0
+      baseurl: https://example.com/repo
     - name: my-other-repo-name # REQUIRED key
-      metalink: http://example.com/metalink?repo=mydistro
+      metalink: https://example.com/metalink?repo=mydistro
       gpgcheck: 0
 
 # OPTIONAL


### PR DESCRIPTION
It's still astonishing how many people offer RPMs only over http,
years after https://theupdateframework.github.io/ was posted
etc.  Let's not encourage it :smile:
