### PR TITLE
Refactor code and add Build API support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,6 @@ RUN dnf install -y \
 		nmap-ncat && \
 	dnf clean all
 
-RUN pip3 install \
-		python-novaclient \
-		awscli \
-		PyYAML \
-		jinja2
-
 # There's a tricky bit here. We mount $PWD at $PWD in the
 # container so that when we do the nested docker run in the
 # main script, the paths the daemon receives will still be
@@ -59,5 +53,7 @@ LABEL RUN="/usr/bin/docker run --rm --privileged \
 ENV PYTHONUNBUFFERED 1
 
 COPY . /redhat-ci
+
+RUN pip3 install -r /redhat-ci/requirements.txt
 
 CMD ["/redhat-ci/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ LABEL RUN="/usr/bin/docker run --rm --privileged \
              -e BUILD_ID \
              -e RHCI_DEBUG_NO_TEARDOWN \
              -e RHCI_DEBUG_ALWAYS_RUN \
+             -e RHCI_DEBUG_USE_NODE \
              \${OPT1} \
              \${IMAGE}"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-novaclient
 PyYAML
 jinja2
 awscli
+pykwalify

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+python-novaclient
+PyYAML
+jinja2
+awscli

--- a/sample.redhat-ci.yml
+++ b/sample.redhat-ci.yml
@@ -95,12 +95,11 @@ build:
     # OPTIONAL
     # Customize the configuration step.
     config-opts: >
-        --prefix=/usr
-        --libdir=/usr/lib64
-        CFLAGS='-ggdb -O0'
+        --enable-systemd
+        CFLAGS='-fsanitize=undefined'
     # OPTIONAL
     # Customize the build step.
-    build-opts: -j4
+    build-opts: MYVAR=1
     # OPTIONAL
     # Customize the install step.
     install-opts: DESTDIR=$PWD/install

--- a/sample.redhat-ci.yml
+++ b/sample.redhat-ci.yml
@@ -93,8 +93,9 @@ tests:
     - make installcheck
 
 # OPTIONAL
-# Maximum time to allow for the test. Accepts the same
-# syntax as timeout(1). If omitted, defaults to '2h'.
+# Time to allow before aborting tests. Must satisfy regex
+# '[0-9]+[smh]'. If omitted, defaults to '2h', which is the
+# maximum.
 timeout: 30m
 
 # OPTIONAL

--- a/sample.redhat-ci.yml
+++ b/sample.redhat-ci.yml
@@ -83,6 +83,28 @@ env:
     VAR1: val1
     VAR2: val2
 
+# OPTIONAL
+# If the project follows the Build API (see
+# https://github.com/cgwalters/build-api), you may specify
+# the 'build' key to automatically build the code.
+build: true
+
+# You may customize the build further by providing a dict
+# instead.
+build:
+    # OPTIONAL
+    # Customize the configuration step.
+    config-opts: >
+        --prefix=/usr
+        --libdir=/usr/lib64
+        CFLAGS='-ggdb -O0'
+    # OPTIONAL
+    # Customize the build step.
+    build-opts: -j4
+    # OPTIONAL
+    # Customize the install step.
+    install-opts: DESTDIR=$PWD/install
+
 # REQUIRED
 # Put the tasks to be executed in the 'tests' key. They are
 # run from the root of the repo.

--- a/spawner.py
+++ b/spawner.py
@@ -47,11 +47,12 @@ def parse_suites():
     nsuites = 0
     branch = os.environ.get('github_branch')
     for idx, suite in enumerate(parser.load_suites(yml_file)):
-        branches = suite.get('branches', ['master'])
-        if branch is not None and branch not in branches:
-            print("INFO: %s suite not defined to run for branch %s." %
-                  (common.ordinal(idx + 1), branch))
-            continue
+        if len(os.environ.get('RHCI_DEBUG_ALWAYS_RUN', '')) == 0:
+            branches = suite.get('branches', ['master'])
+            if branch is not None and branch not in branches:
+                print("INFO: %s suite not defined to run for branch %s." %
+                      (common.ordinal(idx + 1), branch))
+                continue
         suite_dir = 'state/suite-%d/parsed' % nsuites
         parser.flush_suite(suite, suite_dir)
         nsuites += 1

--- a/spawner.py
+++ b/spawner.py
@@ -8,7 +8,11 @@ import sys
 import traceback
 import subprocess
 
+from yaml.scanner import ScannerError
+from pykwalify.errors import SchemaError
+
 import utils.parser as parser
+import utils.common as common
 import utils.ghupdate as ghupdate
 
 
@@ -17,13 +21,12 @@ def main():
 
     try:
         n = parse_suites()
-    except SyntaxError as e:
-        # print the error to give feedback, but exit nicely
+    except ScannerError:
+        update_gh('error', "YAML syntax error.")
+    except SchemaError as e:
+        # print the error to give feedback in the logs, but exit nicely
         traceback.print_exc()
-        msg = e.msg
-        if e.__cause__ is not None:
-            msg += ": " + e.__cause__.msg
-        update_gh('error', msg)
+        update_gh('error', "YAML semantic error.")
     else:
         if n > 0:
             spawn_testrunners(n)
@@ -47,7 +50,7 @@ def parse_suites():
         branches = suite.get('branches', ['master'])
         if branch is not None and branch not in branches:
             print("INFO: %s suite not defined to run for branch %s." %
-                  (parser.ordinal(idx + 1), branch))
+                  (common.ordinal(idx + 1), branch))
             continue
         suite_dir = 'state/suite-%d/parsed' % nsuites
         parser.flush_suite(suite, suite_dir)

--- a/testrunner
+++ b/testrunner
@@ -36,25 +36,23 @@ main() {
 
     provision_env
 
+    prepare_env
+
     run_tests
 
-    prep_artifacts
+    fetch_artifacts
+
+    s3_upload
 
     final_github_update
 }
 
 provision_env() {
-
     if containerized; then
-
+        ensure_teardown_container
         provision_container
-
     else
-
-        # Before we even provision, let's make sure we will
-        # teardown at exit time.
         ensure_teardown_node
-
         provision_node
     fi
 }
@@ -69,21 +67,9 @@ provision_container() {
         exit 0
     fi
 
-    # Everything that will be bind-mounted goes there.
-    mkdir $state/cnt
-
-    cp -a checkouts/$github_repo $state/cnt/checkout
-
-    # let's just make it always exist so we don't have to
-    # use eval during docker run
-    touch $state/cnt/rhci-extras.repo
-    if [ -f $state/parsed/rhci-extras.repo ]; then
-        cp $state/parsed/rhci-extras.repo $state/cnt
-    fi
-
-    gen_worker_script
-
-    cp $state/worker.sh $state/cnt
+    sudo docker run -d \
+        --cidfile $state/cid \
+        "$image" sleep infinity
 }
 
 provision_node() {
@@ -93,15 +79,21 @@ provision_node() {
 
     update_github pending "Provisioning test node."
 
-    # XXX: We hardcode m1.small for now, but these really
-    # should be specified indirectly from the .redhat-ci
-    # YAML file through e.g. min-* vars.
-    env \
-        os_image="$image" \
-        os_flavor=m1.small \
-        os_name_prefix=github-ci-testnode \
-        os_user_data="$THIS_DIR/utils/user-data" \
-        "$THIS_DIR/utils/os_provision.py" $state
+    # substitute node to use in "<name>:<ip>" format
+    if [ -n "${RHCI_DEBUG_USE_NODE:-}" ]; then
+        echo "${RHCI_DEBUG_USE_NODE%:*}" > $state/node_name
+        echo "${RHCI_DEBUG_USE_NODE#*:}" > $state/node_addr
+    else
+        # XXX: We hardcode m1.small for now, but these really
+        # should be specified indirectly from the .redhat-ci
+        # YAML file through e.g. min-* vars.
+        env \
+            os_image="$image" \
+            os_flavor=m1.small \
+            os_name_prefix=github-ci-testnode \
+            os_user_data="$THIS_DIR/utils/user-data" \
+            "$THIS_DIR/utils/os_provision.py" $state
+    fi
 
     ssh_setup_key
 
@@ -114,19 +106,29 @@ provision_node() {
         fi
         deploy_ostree
     fi
+}
 
-    if [ -f $state/parsed/packages ] && on_atomic_host; then
-        overlay_packages
+prepare_env() {
+    local upload_dir=$state/$github_commit.$state_idx.$RANDOM
+    echo $upload_dir > $state/upload_dir
+    mkdir $upload_dir
+
+    # inject extra repos before installing packages
+    if [ -f $state/parsed/rhci-extras.repo ]; then
+        envcmd mkdir -p /etc/yum.repos.d
+        envcp $state/parsed/rhci-extras.repo /etc/yum.repos.d
     fi
 
-    push_repo
+    if [ -f $state/parsed/packages ]; then
+        if on_atomic_host; then
+            overlay_packages
+        else
+            install_packages
+        fi
+    fi
 
-    inject_yum_repos
-
-    gen_worker_script
-
-    # push it out to the node
-    vmscp $state/worker.sh root@$(cat $state/node_addr):/root
+    envcmd mkdir /var/tmp/checkout
+    envcp checkouts/$github_repo/. /var/tmp/checkout
 }
 
 ssh_setup_key() {
@@ -134,27 +136,6 @@ ssh_setup_key() {
     cat > $state/node_key <<< "$os_privkey"
     chmod 0600 $state/node_key
     set -x
-}
-
-vmssh() {
-    ssh -q -i $state/node_key \
-        -o StrictHostKeyChecking=no \
-        -o PasswordAuthentication=no \
-        -o UserKnownHostsFile=/dev/null \
-        root@$(cat $state/node_addr) "$@"
-}
-
-vmscp() {
-    scp -q -i $state/node_key \
-        -o StrictHostKeyChecking=no \
-        -o PasswordAuthentication=no \
-        -o UserKnownHostsFile=/dev/null "$@"
-}
-
-vmreboot() {
-    vmssh systemctl reboot || :
-    sleep 3 # give time for port to go down
-    ssh_wait
 }
 
 ssh_wait() {
@@ -193,56 +174,6 @@ ssh_wait() {
         echo "ERROR: Timed out while waiting for SSH."
         return 1
     fi
-}
-
-push_repo() {
-    local node_addr=$(cat $state/node_addr)
-
-    rsync --quiet -az --no-owner --no-group \
-        -e "ssh -q -i $state/node_key \
-                   -o StrictHostKeyChecking=no \
-                   -o PasswordAuthentication=no \
-                   -o UserKnownHostsFile=/dev/null" \
-        checkouts/$github_repo/ root@$node_addr:/root/checkout/
-}
-
-gen_worker_script() {
-
-    # let's build the worker script that will be executed on the node
-    touch $state/worker.sh
-
-    append() {
-        echo "$@" >> $state/worker.sh
-    }
-
-    append "#!/bin/bash"
-    append "set -xeuo pipefail"
-    append
-
-    # on AH, we layer packages during provisioning
-    if ! on_atomic_host && [ -f $state/parsed/packages ]; then
-        append yum install -y "$(cat $state/parsed/packages)"
-    fi
-
-    if [ -f $state/parsed/envs ]; then
-        cat $state/parsed/envs >> $state/worker.sh
-    fi
-
-    append cd checkout
-
-    cat $state/parsed/tests >> $state/worker.sh
-
-    unset -f append
-}
-
-inject_yum_repos() {
-    local node_addr=$(cat $state/node_addr)
-
-    if [ ! -f $state/parsed/rhci-extras.repo ]; then
-        return 0
-    fi
-
-    vmscp $state/parsed/rhci-extras.repo root@$node_addr:/etc/yum.repos.d
 }
 
 deploy_ostree() {
@@ -301,149 +232,114 @@ deploy_ostree() {
 }
 
 overlay_packages() {
+    local upload_dir=$(cat $state/upload_dir)
 
-    # do a prelim check to be more helpful
-    for pkg in $(cat $state/parsed/packages); do
-        if vmssh rpm -q "$pkg"; then
-            update_github error "Package '$pkg' is already installed."
-            exit 0
-        fi
-    done
+    local rc=0
+    logged_envcmd $upload_dir/setup.log / - - \
+        rpm-ostree install "$(cat $state/parsed/packages)" || rc=$?
 
-    if ! vmssh rpm-ostree install $(cat $state/parsed/packages); then
-        update_github error "Could not layer packages."
+    if [ $rc != 0 ]; then
+        s3_upload
+        update_github error "Could not layer packages." "$(cat $state/url)"
         exit 0
     fi
 
     vmreboot
 }
 
-run_tests() {
-    echo $RANDOM > $state/random
-    local upload_dir=$state/$github_commit.$state_idx.$(cat $state/random)
-    mkdir $upload_dir
+install_packages() {
+    local upload_dir=$(cat $state/upload_dir)
 
-    update_github pending "Running tests."
-
-    # Seed output.txt with useful information
-    echo "### $(date --utc)" > $upload_dir/output.txt
-
-    if [ -n "${github_branch:-}" ]; then
-        echo "### Testing branch $github_branch" >> $upload_dir/output.txt
-    else
-        echo -n "### Testing PR #$github_pull_id" >> $upload_dir/output.txt
-        # NB: is_merge_sha is in the top-level global state dir
-        if [ ! -f state/is_merge_sha ]; then
-            echo " (WARNING: cannot test merge, check for conflicts)" \
-                >> $upload_dir/output.txt
-        else
-            echo >> $upload_dir/output.txt
-        fi
-    fi
-
-    if [ -n "${BUILD_ID:-}" ]; then
-        echo "### BUILD_ID $BUILD_ID" >> $upload_dir/output.txt
+    mgr=yum
+    if envcmd rpm -q dnf; then
+        mgr=dnf
     fi
 
     local rc=0
-    local timeout=$(cat $state/parsed/timeout)
+    logged_envcmd $upload_dir/setup.log / - - \
+        $mgr install -y "$(cat $state/parsed/packages)" || rc=$?
 
-    if ! containerized; then
-        local node_addr=$(cat $state/node_addr)
-
-        timeout --kill-after=30s "$timeout" \
-            ssh -q -i $state/node_key \
-                   -o StrictHostKeyChecking=no \
-                   -o UserKnownHostsFile=/dev/null \
-                   root@$node_addr "sh worker.sh 2>&1" | \
-            tee -a $upload_dir/output.txt || rc=$?
-    else
-        # We need a full path for this
-        local mnt=$(realpath $state/cnt)
-
-        # We use sudo below to make it more convenient for running unprivileged
-        # on dev machines. Though because we use timeout, sudo doesn't have
-        # control of the TTY, so we use it beforehand so it can cache
-        # credentials.
-        sudo true
-
-        # Setting a timeout on docker run is not reliable since it's the daemon
-        # running it. And we don't want to trust the timeout *inside* the
-        # container as well. So we follow up with a docker kill.
-        timeout --kill-after=30s "$timeout" \
-            sudo docker run --rm \
-                --workdir / \
-                --cidfile $state/cid \
-                -v "$mnt/checkout:/checkout:z" \
-                -v "$mnt/worker.sh:/worker.sh:z" \
-                -v "$mnt/rhci-extras.repo:/etc/yum.repos.d/rhci-extras.repo:z" \
-                "$(cat $state/parsed/image)" sh -c "sh worker.sh 2>&1" | \
-            tee -a $upload_dir/output.txt || rc=$?
-
-        if [ -f $state/cid ] \
-              && sudo docker inspect $(cat $state/cid) &>/dev/null; then
-            # ignore errors in case of TOCTOU race
-            sudo docker kill $(cat $state/cid) || :
-        fi
+    if [ $rc != 0 ]; then
+        s3_upload
+        update_github error "Could not install packages." "$(cat $state/url)"
+        exit 0
     fi
+}
+
+run_tests() {
+    local upload_dir=$(cat $state/upload_dir)
+
+    update_github pending "Running tests."
+
+    local rc=0
+
+    max_date=$(($(date +%s) + $(cat $state/parsed/timeout)))
+
+    while IFS='' read -r line || [[ -n $line ]]; do
+
+        local timeout=$(($max_date - $(date +%s)))
+
+        if [ $timeout -le 0 ]; then
+            echo "### TIMED OUT" >> $upload_dir/output.log
+            rc=137
+            break
+        fi
+
+        rc=0
+        logged_envcmd \
+            $upload_dir/output.log /var/tmp/checkout \
+            $state/parsed/envs $timeout "$line" || rc=$?
+
+        if [ $rc != 0 ]; then
+            break
+        fi
+
+    done < $state/parsed/tests
 
     echo "$rc" > $state/rc
 }
 
-prep_artifacts() {
-    local upload_dir=$state/$github_commit.$state_idx.$(cat $state/random)
+fetch_artifacts() {
+    local upload_dir=$(cat $state/upload_dir)
 
     # let's pull back the artifacts
     if [ -f $state/parsed/artifacts ]; then
-
-        # use a variable instead or `read` misses the last non-newline
-        # terminated line
-        local artifacts=$(cat $state/parsed/artifacts)
 
         mkdir $upload_dir/artifacts
 
         if ! containerized; then
             local node_addr=$(cat $state/node_addr)
 
-            # So apparently the rsync in RHEL/Centos 7 is too
-            # old to have --ignore-missing-args, which would be
-            # really handy here. Fun/sad fact: that feature has
-            # been upstream since *2009*. Wow.
-
-            #rsync -raz --quiet --delete-missing-args --no-owner --no-group \
-            #    -e "ssh -q -i $state/node_key \
-            #               -o StrictHostKeyChecking=no \
-            #               -o PasswordAuthentication=no \
-            #               -o UserKnownHostsFile=/dev/null" \
-            #    --files-from=$state/parsed/artifacts \
-            #    root@$node_addr:checkout $upload_dir/artifacts/
-
-            while read artifact; do
-                vmscp -r "root@$node_addr:checkout/$artifact" \
-                    $upload_dir/artifacts || :
-            done <<< "$artifacts"
-        else
-            # NB: We ran as root, so chown in case we're unprivileged. This is
-            # more as a helper for when we do local testing, since we're always
-            # root in the container.
-            while read artifact; do
-                path="$state/cnt/checkout/$artifact"
-                if sudo [ -e "$path" ]; then
-                    sudo chown -R $UID:$UID $path
-                    cp -r "$path" $upload_dir/artifacts
+            while IFS='' read -r artifact || [[ -n $artifact ]]; do
+                path="/var/tmp/checkout/$artifact"
+                if vmssh [ -e "$path" ]; then
+                    vmscp -r "root@$node_addr:$path" $upload_dir/artifacts
                 fi
-            done <<< "$artifacts"
+            done < $state/parsed/artifacts
+        else
+            local cid=$(cat $state/cid)
+            while IFS='' read -r artifact || [[ -n $artifact ]]; do
+                path="/var/tmp/checkout/$artifact"
+                if sudo docker exec $cid [ -e "$path" ]; then
+                    sudo docker cp "$cid:$path" $upload_dir/artifacts
+                fi
+            done < $state/parsed/artifacts
         fi
+    fi
+}
 
-        local indexer=$(realpath $THIS_DIR/utils/indexer.py)
+s3_upload() {
+    local indexer=$(realpath $THIS_DIR/utils/indexer.py)
+    local upload_dir=$(cat $state/upload_dir)
+
+    # if we just have output.log, then just link directly to that
+    if [ -f $upload_dir/output.log ] && \
+       [ $(find $upload_dir -mindepth 1 | wc -l) == 1 ]; then
+        local s3_object=output.log
+    else
         # don't change directory in current session
         ( cd $upload_dir && $indexer )
-
-        # we're gonna link to the index file
-        local s3_object="index.html"
-    else
-        # we'll link directly to the output.txt file
-        local s3_object="output.txt"
+        local s3_object=index.html
     fi
 
     # only actually upload if we're given $s3_prefix
@@ -492,6 +388,151 @@ final_github_update() {
     update_github $ghstate "$desc" "$url"
 }
 
+# $1 -- log file
+# $2 -- workdir
+# $3 -- envfile or -
+# $4 -- timeout or -
+logged_envcmd() {
+    local logfile=$1; shift
+    local workdir=$1; shift
+    local envfile=$1; shift
+    local timeout=$1; shift
+
+    # seed with standard info
+    if [ ! -f $logfile ]; then
+
+        echo "### $(date --utc)" > $logfile
+
+        if [ -n "${github_branch:-}" ]; then
+            echo "### Branch $github_branch" >> $logfile
+        else
+            echo -n "### PR #$github_pull_id" >> $logfile
+            # NB: is_merge_sha is in the top-level global state dir
+            if [ ! -f state/is_merge_sha ]; then
+                echo " (WARNING: not merge sha, check for conflicts)" \
+                    >> $logfile
+            else
+                echo >> $logfile
+            fi
+        fi
+
+        if [ -n "${BUILD_ID:-}" ]; then
+            echo "### BUILD_ID $BUILD_ID" >> $logfile
+        fi
+    fi
+
+    echo '>>>' "$@" >> $logfile
+
+    # we just create a script and run that to make
+    # invocation and redirection easier
+    echo "set -euo pipefail" > $state/worker.sh
+    if [ $envfile != - ] && [ -f $envfile ]; then
+        cat $envfile >> $state/worker.sh
+    fi
+    echo "exec 2>&1" >> $state/worker.sh
+    echo "cd $workdir" >> $state/worker.sh
+    echo "$@" >> $state/worker.sh
+
+    envcp $state/worker.sh /var/tmp
+
+    local start=$(date +%s)
+
+    rc=0
+    timed_envcmd $timeout sh /var/tmp/worker.sh | tee -a $logfile || rc=$?
+
+    local duration=$(($(date +%s) - $start))
+
+    if [ $rc == 0 ]; then
+        echo "### COMPLETED IN ${duration}s" >> $logfile
+    elif [ $rc == 137 ]; then
+        echo "### TIMED OUT AFTER ${duration}s" >> $logfile
+    else
+        echo "### EXITED WITH CODE $rc AFTER ${duration}s" >> $logfile
+    fi
+
+    return $rc
+}
+
+# $1 -- timeout or -
+timed_envcmd() {
+    timeout=$1; shift
+
+    if [[ $timeout == - ]]; then
+        timeout=infinity
+    fi
+
+    # There's a tricky bit to note here, docker exec and ssh
+    # don't handle arguments exactly the same way. SSH will
+    # effectively do a 'sh -c' on the passed command, which
+    # means that quoting might be an issue.
+
+    if containerized; then
+        local cid=$(cat $state/cid)
+        sudo timeout --signal=KILL $timeout \
+            docker exec $cid "$@"
+    else
+        local node_addr=$(cat $state/node_addr)
+        timeout --signal=KILL $timeout \
+            ssh -q -n -i $state/node_key \
+                -o StrictHostKeyChecking=no \
+                -o PasswordAuthentication=no \
+                -o UserKnownHostsFile=/dev/null \
+                root@$(cat $state/node_addr) "$@"
+    fi
+}
+
+envcmd() {
+    timed_envcmd infinity "$@"
+}
+
+envcp() {
+    target=$1; shift
+    remote=$1; shift
+
+    # N.B.: docker cp and rsync have almost the same
+    # semantics, which is nice. One exception is that docker
+    # wants 'dir/.' to signify copying dir contents, whereas
+    # rsync is happy with just 'dir/', so always use '/.'.
+    # Also, rsync creates nonexistent dirs, whereas docker
+    # does not, so explicitly mkdir beforehand.
+
+    if containerized; then
+        local cid=$(cat $state/cid)
+        sudo docker cp $target $cid:$remote
+    else
+        local node_addr=$(cat $state/node_addr)
+        rsync --quiet -az --no-owner --no-group \
+            -e "ssh -q -i $state/node_key \
+                       -o StrictHostKeyChecking=no \
+                       -o PasswordAuthentication=no \
+                       -o UserKnownHostsFile=/dev/null" \
+            $target root@$node_addr:$remote
+    fi
+}
+
+vmssh() {
+    # NB: we use -n because stdin may be in use (e.g. in a
+    # bash while read loop)
+    ssh -q -n -i $state/node_key \
+        -o StrictHostKeyChecking=no \
+        -o PasswordAuthentication=no \
+        -o UserKnownHostsFile=/dev/null \
+        root@$(cat $state/node_addr) "$@"
+}
+
+vmscp() {
+    scp -q -i $state/node_key \
+        -o StrictHostKeyChecking=no \
+        -o PasswordAuthentication=no \
+        -o UserKnownHostsFile=/dev/null "$@"
+}
+
+vmreboot() {
+    vmssh systemctl reboot || :
+    sleep 3 # give time for port to go down
+    ssh_wait
+}
+
 update_github() {
     local context=$(cat $state/parsed/context)
     common_update_github "$context" "$@"
@@ -521,6 +562,18 @@ teardown_node() {
 ensure_teardown_node() {
     if [ -z "${RHCI_DEBUG_NO_TEARDOWN:-}" ]; then
         trap teardown_node EXIT
+    fi
+}
+
+teardown_container() {
+    if [ -f $state/cid ]; then
+        sudo docker rm -f $(cat $state/cid)
+    fi
+}
+
+ensure_teardown_container() {
+    if [ -z "${RHCI_DEBUG_NO_TEARDOWN:-}" ]; then
+        trap teardown_container EXIT
     fi
 }
 

--- a/testrunner
+++ b/testrunner
@@ -65,7 +65,7 @@ provision_container() {
     # Let's pre-pull the image so that it doesn't count
     # as part of the test timeout.
     if ! sudo docker pull "$image"; then
-        update_github failure "ERROR: Could not pull image '$image'."
+        update_github error "Could not pull image '$image'."
         exit 0
     fi
 
@@ -109,7 +109,7 @@ provision_node() {
 
     if [ -f $state/parsed/ostree_revision ]; then
         if ! on_atomic_host; then
-            update_github failure "ERROR: Cannot specify 'ostree' on non-AH."
+            update_github error "Cannot specify 'ostree' on non-AH."
             exit 0
         fi
         deploy_ostree
@@ -263,7 +263,7 @@ deploy_ostree() {
         if [ $rc == 77 ]; then
             skip_reboot=1
         elif [ $rc != 0 ]; then
-            update_github failure "ERROR: Failed to upgrade or deploy."
+            update_github error "Failed to upgrade or deploy."
             exit 0
         fi
     else
@@ -289,7 +289,7 @@ deploy_ostree() {
             if [ $rc == 77 ]; then
                 skip_reboot=1
             elif [ $rc != 0 ]; then
-                update_github failure "ERROR: Failed to upgrade or deploy."
+                update_github error "Failed to upgrade or deploy."
                 exit 0
             fi
         fi
@@ -305,13 +305,13 @@ overlay_packages() {
     # do a prelim check to be more helpful
     for pkg in $(cat $state/parsed/packages); do
         if vmssh rpm -q "$pkg"; then
-            update_github failure "ERROR: Package '$pkg' is already installed."
+            update_github error "Package '$pkg' is already installed."
             exit 0
         fi
     done
 
     if ! vmssh rpm-ostree install $(cat $state/parsed/packages); then
-        update_github failure "ERROR: Could not layer packages."
+        update_github error "Could not layer packages."
         exit 0
     fi
 

--- a/testrunner
+++ b/testrunner
@@ -361,6 +361,7 @@ fetch_artifacts() {
 
         mkdir $upload_dir/artifacts
 
+        local fetched_at_least_one=0
         if ! containerized; then
             local node_addr=$(cat $state/node_addr)
 
@@ -368,6 +369,7 @@ fetch_artifacts() {
                 path="/var/tmp/checkout/$artifact"
                 if vmssh [ -e "$path" ]; then
                     vmscp -r "root@$node_addr:$path" $upload_dir/artifacts
+                    fetched_at_least_one=1
                 fi
             done < $state/parsed/artifacts
         else
@@ -376,8 +378,13 @@ fetch_artifacts() {
                 path="/var/tmp/checkout/$artifact"
                 if sudo docker exec $cid [ -e "$path" ]; then
                     sudo docker cp "$cid:$path" $upload_dir/artifacts
+                    fetched_at_least_one=1
                 fi
             done < $state/parsed/artifacts
+        fi
+
+        if [ $fetched_at_least_one == 0 ]; then
+            rm -rf $upload_dir/artifacts
         fi
     fi
 }

--- a/testrunner
+++ b/testrunner
@@ -317,8 +317,10 @@ build_and_test() {
             fi
         fi
 
+        local njobs=$(envcmd getconf _NPROCESSORS_ONLN)
+
         echo "./configure $config_opts" >> $state/build.sh
-        echo "make all $build_opts" >> $state/build.sh
+        echo "make all --jobs $njobs $build_opts" >> $state/build.sh
         echo "make install $install_opts" >> $state/build.sh
 
         local max_date=$(($(date +%s) + $timeout))

--- a/testrunner
+++ b/testrunner
@@ -255,6 +255,17 @@ install_packages() {
         mgr=dnf
     fi
 
+    # This is hacky and sad. Preemptively try to refresh
+    # yum/dnf cache to work around flaky distro infras.
+
+    local retries=5
+    while [ $retries -gt 0 ]; do
+        if envcmd $mgr makecache; then
+            break
+        fi
+        retries=$((retries - 1))
+    done
+
     local rc=0
     logged_envcmd $upload_dir/setup.log / - - \
         $mgr install -y "$(cat $state/parsed/packages)" || rc=$?

--- a/testrunner
+++ b/testrunner
@@ -38,7 +38,7 @@ main() {
 
     prepare_env
 
-    run_tests
+    build_and_test
 
     fetch_artifacts
 
@@ -77,7 +77,7 @@ provision_node() {
     # the allowed fields for "distro" are the same as the image name in glance
     local image=$(cat $state/parsed/distro)
 
-    update_github pending "Provisioning test node."
+    update_github pending "Provisioning test node..."
 
     # substitute node to use in "<name>:<ip>" format
     if [ -n "${RHCI_DEBUG_USE_NODE:-}" ]; then
@@ -266,35 +266,87 @@ install_packages() {
     fi
 }
 
-run_tests() {
-    local upload_dir=$(cat $state/upload_dir)
+run_loop() {
+    local timeout=$1; shift
+    local logfile=$1; shift
+    local workdir=$1; shift
+    local testfile=$1; shift
+    local envfile=$1; shift
 
-    update_github pending "Running tests."
-
-    local rc=0
-
-    max_date=$(($(date +%s) + $(cat $state/parsed/timeout)))
-
+    local max_date=$(($(date +%s) + $timeout))
     while IFS='' read -r line || [[ -n $line ]]; do
 
-        local timeout=$(($max_date - $(date +%s)))
-
+        timeout=$(($max_date - $(date +%s)))
         if [ $timeout -le 0 ]; then
-            echo "### TIMED OUT" >> $upload_dir/output.log
+            echo "### TIMED OUT" >> $logfile
             rc=137
             break
         fi
 
         rc=0
-        logged_envcmd \
-            $upload_dir/output.log /var/tmp/checkout \
-            $state/parsed/envs $timeout "$line" || rc=$?
+        logged_envcmd $logfile $workdir $envfile $timeout "$line" || rc=$?
 
         if [ $rc != 0 ]; then
             break
         fi
 
-    done < $state/parsed/tests
+    done < "$testfile"
+
+    return $rc
+}
+
+build_and_test() {
+    local upload_dir=$(cat $state/upload_dir)
+    local timeout=$(cat $state/parsed/timeout)
+    local checkout=checkouts/$github_repo
+    local rc=0
+
+    if [ -f $state/parsed/build ]; then
+        local config_opts=$(cat $state/parsed/build.config_opts)
+        local build_opts=$(cat $state/parsed/build.build_opts)
+        local install_opts=$(cat $state/parsed/build.install_opts)
+
+        update_github pending "Building..."
+
+        touch $state/build.sh
+        if [ ! -f $checkout/configure ]; then
+            if [ -f $checkout/autogen.sh ]; then
+                echo "NOCONFIGURE=1 ./autogen.sh" >> $state/build.sh
+            elif [ -f $checkout/autogen ]; then
+                echo "NOCONFIGURE=1 ./autogen" >> $state/build.sh
+            fi
+        fi
+
+        echo "./configure $config_opts" >> $state/build.sh
+        echo "make all $build_opts" >> $state/build.sh
+        echo "make install $install_opts" >> $state/build.sh
+
+        local max_date=$(($(date +%s) + $timeout))
+
+        rc=0
+        run_loop \
+            $timeout \
+            $upload_dir/build.log \
+            /var/tmp/checkout \
+            $state/build.sh \
+            $state/parsed/envs || rc=$?
+
+        if [ $rc != 0 ]; then
+            echo "$rc" > $state/rc
+            return
+        fi
+
+        timeout=$(($max_date - $(date +%s)))
+    fi
+
+    update_github pending "Running tests..."
+
+    run_loop \
+        $timeout \
+        $upload_dir/output.log \
+        /var/tmp/checkout \
+        $state/parsed/tests \
+        $state/parsed/envs || rc=$?
 
     echo "$rc" > $state/rc
 }

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,0 +1,25 @@
+import re
+
+# http://stackoverflow.com/a/39596504/308136
+def ordinal(n):
+    suffix = ['th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th']
+    if n < 0:
+        n *= -1
+    n = int(n)
+
+    if n % 100 in (11, 12, 13):
+        s = 'th'
+    else:
+        s = suffix[n % 10]
+
+    return str(n) + s
+
+# normalize timeout str to seconds
+def str_to_timeout(s):
+    assert re.match('^[0-9]+[smh]$', s)
+    timeout = int(s[:-1])
+    if s.endswith('m'):
+        timeout *= 60
+    if s.endswith('h'):
+        timeout *= 60 * 60
+    return timeout

--- a/utils/ext_schema.py
+++ b/utils/ext_schema.py
@@ -1,0 +1,48 @@
+import utils.common as common
+
+from pykwalify.core import Core
+from pykwalify.errors import SchemaError
+
+def ext_testenv(value, rule_obj, path):
+    if 'host' in value and 'container' in value:
+        raise SchemaError("only one of 'host' and 'container' allowed")
+    if 'host' not in value and 'container' not in value:
+        raise SchemaError("one of 'host' or 'container' required")
+    return True
+
+def ext_repos(value, rule_obj, path):
+    # Until this is fixed:
+    # https://github.com/Grokzen/pykwalify/issues/67
+    if type(value) is not list:
+        raise SchemaError("expected list of dicts")
+    for i, repo in enumerate(value):
+        if type(repo) is not dict:
+            raise SchemaError("repo %d is not a dict" % i)
+        if 'name' not in repo:
+            raise SchemaError("repo %d missing key 'name'" % i)
+        for key in repo:
+            if type(repo[key]) not in [int, str]:
+                raise SchemaError("key '%s' of repo %d is not str or int" % (key, i))
+    return True
+
+def ext_ostree(value, rule_obj, path):
+    if type(value) is str:
+        if value != "latest":
+            raise SchemaError("expected string 'latest'")
+    elif type(value) is dict:
+        schema = { 'mapping':
+                   { 'remote': { 'type': 'str' },
+                     'branch': { 'type': 'str' },
+                     'revision' : { 'type': 'str' }
+                   }
+                 }
+        c = Core(source_data=value, schema_data=schema)
+        c.validate()
+    else:
+        raise SchemaError("expected str or map")
+    return True
+
+def ext_timeout(value, rule_obj, path):
+    if common.str_to_timeout(value) > (2 * 60 * 60):
+        raise SchemaError("timeout cannot be greater than 2 hours")
+    return True

--- a/utils/ext_schema.py
+++ b/utils/ext_schema.py
@@ -46,3 +46,17 @@ def ext_timeout(value, rule_obj, path):
     if common.str_to_timeout(value) > (2 * 60 * 60):
         raise SchemaError("timeout cannot be greater than 2 hours")
     return True
+
+def ext_build(value, rule_obj, path):
+    if type(value) not in [dict, bool]:
+        raise SchemaError("expected bool or map")
+    if type(value) is dict:
+        schema = { 'mapping':
+                   { 'config-opts': { 'type': 'str' },
+                     'build-opts': { 'type': 'str' },
+                     'install-opts': { 'type': 'str' }
+                   }
+                 }
+        c = Core(source_data=value, schema_data=schema)
+        c.validate()
+    return True

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -7,9 +7,15 @@
 
 import re
 import os
+import sys
 import yaml
 import shlex
 import argparse
+
+import utils.common as common
+
+from pykwalify.core import Core
+from pykwalify.errors import SchemaError
 
 
 def load_suites(filepath):
@@ -23,13 +29,13 @@ def load_suites(filepath):
                 suite = _merge(suite, raw_yaml)
                 _validate(suite, contexts)
                 yield suite
-            except SyntaxError as e:
+            except SchemaError as e:
                 # if it happens on the very first document, let's just give the
                 # exact error directly
                 if idx == 0:
                     raise e
-                msg = "failed to parse %s testsuite" % ordinal(idx + 1)
-                raise SyntaxError(msg) from e
+                msg = "failed to parse %s testsuite" % common.ordinal(idx + 1)
+                raise SchemaError(msg) from e
 
 
 def _merge(suite, new):
@@ -78,40 +84,12 @@ def _normalize(suite):
 
 def _validate(suite, contexts):
 
-    # XXX: We need a proper full schema validation here.
-    # Maybe using: https://pypi.python.org/pypi/pykwalify
-    # Probably better to just merge this with flush_suite()
-    # since it does the real validation on-the-fly.
-
-    if 'host' in suite and 'container' in suite:
-        raise SyntaxError("expected only one of 'host' and 'container'")
-    elif 'host' in suite:
-        if 'distro' not in suite['host']:
-            raise SyntaxError("expected 'distro' entry in 'host' dict")
-    elif 'container' in suite:
-        if 'image' not in suite['container']:
-            raise SyntaxError("expected 'image' entry in 'container' dict")
-    else:
-        raise SyntaxError("expected one of 'host' or 'container'")
-
-    if 'extra-repos' in suite:
-        repos = suite['extra-repos']
-        if type(repos) is not list:
-            raise SyntaxError("expected a list of dicts for 'extra-repos'")
-        for i, repo in enumerate(suite['extra-repos']):
-            if type(repo) is not dict:
-                raise SyntaxError("expected a list of dicts for 'extra-repos'")
-            if 'name' not in repo:
-                raise SyntaxError("expected 'name' key in extra repo %d" % i)
-
-    if 'tests' not in suite or type(suite['tests']) is not list:
-        raise SyntaxError("expected a list for 'tests'")
-
-    if 'context' not in suite:
-        raise SyntaxError("expected 'context' key")
+    schema = os.path.join(sys.path[0], "utils/schema.yml")
+    c = Core(source_data=suite, schema_files=[schema])
+    c.validate()
 
     if suite['context'] in contexts:
-        raise SyntaxError("duplicate 'context' value detected")
+        raise SchemaError("duplicate 'context' value detected")
 
     contexts.append(suite['context'])
 
@@ -128,16 +106,14 @@ def flush_suite(suite, outdir):
         host = suite['host']
         if 'ostree' in host:
             val = host['ostree']
-            if type(val) is str:  # latest
-                if val != "latest":
-                    raise SyntaxError("invalid value for 'ostree' key" % val)
+            assert type(val) in [str, dict]
+            if type(val) is str:
+                assert val == "latest"
                 write_to_file("ostree_revision", "")
-            elif type(val) is dict:
+            else:
                 write_to_file("ostree_remote", val.get('remote', ''))
                 write_to_file("ostree_branch", val.get('branch', ''))
                 write_to_file("ostree_revision", val.get('revision', ''))
-            else:
-                raise SyntaxError("expected str or dict for 'ostree' key")
         write_to_file("distro", host['distro'])
 
     if 'container' in suite:
@@ -145,7 +121,10 @@ def flush_suite(suite, outdir):
 
     write_to_file("tests", '\n'.join(suite['tests']))
     write_to_file("branches", '\n'.join(suite.get('branches', ['master'])))
-    write_to_file("timeout", suite.get('timeout', '2h'))
+
+    timeout = common.str_to_timeout(suite.get('timeout', '2h'))
+    write_to_file("timeout", str(timeout))
+
     write_to_file("context", suite.get('context'))
 
     if 'extra-repos' in suite:
@@ -169,27 +148,8 @@ def flush_suite(suite, outdir):
     if 'env' in suite:
         envs = ''
         for k, v in suite['env'].items():
-            if re.match('[a-zA-Z_][a-zA-Z0-9_]*', k) is None:
-                raise SyntaxError("invalid env var name '%s'" % k)
-            v = shlex.quote(v)
-            envs += 'export %s=%s\n' % (k, v)
+            envs += 'export %s=%s\n' % (k, shlex.quote(v))
         write_to_file("envs", envs)
-
-
-# http://stackoverflow.com/a/39596504/308136
-# XXX: move to a generic util module
-def ordinal(n):
-    suffix = ['th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th']
-    if n < 0:
-        n *= -1
-    n = int(n)
-
-    if n % 100 in (11, 12, 13):
-        s = 'th'
-    else:
-        s = suffix[n % 10]
-
-    return str(n) + s
 
 
 if __name__ == '__main__':

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -151,6 +151,16 @@ def flush_suite(suite, outdir):
             envs += 'export %s=%s\n' % (k, shlex.quote(v))
         write_to_file("envs", envs)
 
+    if 'build' in suite:
+        v = suite['build']
+        if type(v) is bool and v:
+            write_to_file("build", '')
+        elif type(v) is dict:
+            write_to_file("build", '')
+            write_to_file("build.config_opts", v.get('config-opts', ''))
+            write_to_file("build.build_opts", v.get('build-opts', ''))
+            write_to_file("build.install_opts", v.get('install-opts', ''))
+
 
 if __name__ == '__main__':
 

--- a/utils/schema.yml
+++ b/utils/schema.yml
@@ -34,6 +34,9 @@ mapping:
     mapping:
       regex;(^[a-zA-Z_][a-zA-Z0-9_]*$):
         type: str
+  build:
+    type: any
+    func: ext_build
   tests:
     sequence:
       - type: str

--- a/utils/schema.yml
+++ b/utils/schema.yml
@@ -1,0 +1,47 @@
+extensions:
+  - utils/ext_schema.py
+type: map
+func: ext_testenv
+mapping:
+  host:
+    mapping:
+      distro:
+        type: str
+        required: true
+      ostree:
+        type: any
+        func: ext_ostree
+  container:
+    mapping:
+      image:
+        type: str
+        required: true
+  context:
+    type: str
+    required: true
+  branches:
+    sequence:
+      - type: str
+        unique: true
+  extra-repos:
+    type: any
+    func: ext_repos
+  packages:
+    sequence:
+      - type: str
+        unique: true
+  env:
+    mapping:
+      regex;(^[a-zA-Z_][a-zA-Z0-9_]*$):
+        type: str
+  tests:
+    sequence:
+      - type: str
+    required: true
+  timeout:
+    type: str
+    pattern: '[0-9]+[smh]'
+    func: ext_timeout
+  artifacts:
+    sequence:
+      - type: str


### PR DESCRIPTION
- Use [pykwalify](http://pykwalify.readthedocs.io/) to validate YAML. It's not perfect, but it goes a long way towards strengthening handling of malformed YAML. There is some custom handling required to get the more complex keys checked properly.
- Refactor the testrunner. This is mostly in preparation for sanely adding support for the Build API. Though it adds a lot of nice features, such as:
  - Unified codepaths for containerized and virtualized tests.
  - Stronger timeout handling and environment cleanups.
  - Nicer logs, with time taken per step and separation between package install and testing.
- Add support for the Build API (#11).