### PR TITLE
Add support for required key

### DIFF
--- a/sample.redhat-ci.yml
+++ b/sample.redhat-ci.yml
@@ -80,6 +80,14 @@ branches:
 context: 'CI Tester'
 
 # OPTIONAL
+# Mark this testsuite as required. This causes a special
+# "required" context to be reported to GitHub on branch
+# tests. The result is set to successful only if all
+# testsuites marked as required are also successful. If
+# omitted, defaults to false.
+required: true
+
+# OPTIONAL
 # Additional YUM repositories to inject during provisioning.
 extra-repos:
     - name: my-repo-name # REQUIRED key

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -4,7 +4,6 @@ import os
 import sys
 import yaml
 import shlex
-import argparse
 
 import utils.common as common
 
@@ -197,18 +196,3 @@ def flush_suite(suite, outdir):
                           v.get('build-opts', ''))
             write_to_file(outdir, "build.install_opts",
                           v.get('install-opts', ''))
-
-
-if __name__ == '__main__':
-
-    # Just dump each parsed document in indexed subdirs of
-    # output_dir. Useful for testing and validating.
-
-    argparser = argparse.ArgumentParser()
-    argparser.add_argument('--yml-file', required=True)
-    argparser.add_argument('--output-dir', required=True)
-    args = argparser.parse_args()
-
-    for idx, suite in enumerate(load_suites(args.yml_file)):
-        suite_dir = os.path.join(args.output_dir, str(idx))
-        flush_suite(suite, suite_dir)

--- a/utils/schema.yml
+++ b/utils/schema.yml
@@ -24,13 +24,15 @@ mapping:
           image:
             type: str
             required: true
-  context:
-    type: str
-    required: true
   branches:
     sequence:
       - type: str
         unique: true
+  context:
+    type: str
+    required: true
+  required:
+    type: bool
   extra-repos:
     type: any
     func: ext_repos

--- a/validator.py
+++ b/validator.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+'''
+    Simple script to validate a YAML file.
+    Usage: ./validator.py /my/github/project/.redhat-ci.yml
+'''
+
+import os
+import pprint
+import argparse
+import utils.parser as parser
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('yml_file', help="YAML file to parse and validate")
+argparser.add_argument('--output-dir', metavar="DIR",
+                       help="directory to which to flush suites if desired")
+args = argparser.parse_args()
+
+suite_parser = parser.SuiteParser(args.yml_file)
+for idx, suite in enumerate(suite_parser.parse()):
+    print("INFO: validated suite %d" % idx)
+    pprint.pprint(suite, indent=4)
+    if args.output_dir:
+        suite_dir = os.path.join(args.output_dir, str(idx))
+        parser.flush_suite(suite, suite_dir)
+        print("INFO: flushed to %s" % suite_dir)


### PR DESCRIPTION
This is an easy integration point with bots like homu. Rather than
gating on varying sets of statuses, it can instead just gate on the
'required' context. Projects can then independently define which
testsuites are required to pass before merging.

Related: #18 