### PR TITLE
spawner.py: upload a basic results summary page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyYAML
 jinja2
 awscli
 pykwalify
+boto3

--- a/spawner.py
+++ b/spawner.py
@@ -5,7 +5,7 @@
 
 import os
 import sys
-import random
+import time
 import traceback
 import threading
 import subprocess
@@ -184,7 +184,8 @@ def update_required_context(suites):
     s3_key = '%s/%s/%s.%s/%s' % (os.environ['s3_prefix'],
                                  os.environ['github_repo'],
                                  os.environ['github_commit'],
-                                 random.randint(0, 2**15-1),
+                                 # rough equivalent of date +%s%N
+                                 int(time.time() * 1e9),
                                  'index.html')
 
     with open(tpl_fname) as tplf:

--- a/spawner.py
+++ b/spawner.py
@@ -188,9 +188,7 @@ def update_required_context(suites):
                                  'index.html')
 
     with open(tpl_fname) as tplf:
-        tpl = jinja2.Template(tplf.read(),
-                              extensions=['jinja2.ext.i18n'],
-                              autoescape=True)
+        tpl = jinja2.Template(tplf.read(), autoescape=True)
         data = tpl.render(suites=results_suites)
         upload_to_s3(s3_key, data, 'text/html')
 

--- a/testrunner
+++ b/testrunner
@@ -121,7 +121,7 @@ provision_cluster() {
 }
 
 prepare_env() {
-    local upload_dir=$state/$github_commit.$state_idx.$RANDOM
+    local upload_dir=$state/$github_commit.$state_idx.$(date +%s%N)
     echo $upload_dir > $state/upload_dir
     mkdir $upload_dir
 

--- a/utils/indexer.py
+++ b/utils/indexer.py
@@ -60,7 +60,7 @@ def create_index(dirpath, at_top):
                 index = 'index.html'
             files[name] = name + index
 
-    tpl_fname = dirname(realpath(__file__)) + '/index.j2'
+    tpl_fname = join(dirname(realpath(__file__)), 'index.j2')
     # Render the template to index.html
     with open(tpl_fname, 'r') as tplf:
         tpl = jinja2.Template(

--- a/utils/indexer.py
+++ b/utils/indexer.py
@@ -63,10 +63,7 @@ def create_index(dirpath, at_top):
     tpl_fname = join(dirname(realpath(__file__)), 'index.j2')
     # Render the template to index.html
     with open(tpl_fname, 'r') as tplf:
-        tpl = jinja2.Template(
-            tplf.read(),
-            extensions=['jinja2.ext.i18n'],
-            autoescape=True)
+        tpl = jinja2.Template(tplf.read(), autoescape=True)
 
         with open(join(dirpath, "index.html"), 'w') as f:
             f.write(tpl.render(files=files, at_top=at_top))

--- a/utils/required-index.j2
+++ b/utils/required-index.j2
@@ -1,0 +1,24 @@
+<html>
+  <head>
+    <title>Test results</title>
+  </head>
+<body>
+  Test results
+  <ul>
+{% for name, passed, link in suites -%}
+    {%- if passed -%}
+      {% set bgcolor = "#aae0aa" %}
+    {%- else -%}
+      {% set bgcolor = "#e0aaaa" %}
+    {%- endif -%}
+    <li>
+      <a href="{{ link }}" style="color: black; text-decoration: none">
+        <span style="background-color: {{ bgcolor }}">
+          {{ name }}
+        </span>
+      </a>
+    </li>
+{% endfor %}
+  </ul>
+  </body>
+</html>


### PR DESCRIPTION
Setting the commit status URL to the branch itself when there are
testsuites marked required is not very intuitive. Additionally, the
commit can disappear from the branch, giving users no way to discover
the statuses.

We now instead link to a very simple summary page containing the links
to all the other test results. When redhat-ci is used in combination
with homu, this will be accessible directly from the PR through the
comment homu posts.

Closes: #23