### PR TITLE
spec: also set required context on PRs

### DIFF
--- a/docs/sample.papr.yml
+++ b/docs/sample.papr.yml
@@ -103,13 +103,12 @@ context: 'CI Tester'
 
 # OPTIONAL
 # Mark this testsuite as required. This causes a special
-# "required" context to be reported to GitHub on branch
-# tests. The result is set to successful only if all
-# testsuites marked as required are also successful. This is
-# useful for integration with merge bots, so that they only
-# need to watch for a single status rather than multiple
-# (possibly changing) statuses. If omitted, defaults to
-# false.
+# "required" context to be reported to GitHub. The result is
+# set to successful only if all testsuites marked as
+# required are also successful. This is useful for grouping
+# statuses under a single context to be used by the branch
+# protection settings or by a merge bot, rather than dealing
+# with multiple (possibly changing) statuses.
 required: true
 
 # OPTIONAL

--- a/papr/spawner.py
+++ b/papr/spawner.py
@@ -161,9 +161,17 @@ def count_failures(suites):
 
 def update_required_context(suites):
 
-    # only send 'required' context for branches
+    # Prepare a fallback URL in case something goes really wrong in the tester.
+    # We just link back to the branch/PR for now, though we should probably
+    # just capture the same text we used to update the commit status.
     if 'github_pull_id' in os.environ:
-        return
+        fallback_url = ('https://github.com/%s/pull/%s' %
+                        (os.environ['github_repo'],
+                         os.environ['github_pull_id']))
+    else:
+        fallback_url = ('https://github.com/%s/commits/%s' %
+                        (os.environ['github_repo'],
+                         os.environ['github_branch']))
 
     # don't send 'required' context if we're only targeting some testsuites
     if 'github_contexts' in os.environ:
@@ -185,11 +193,8 @@ def update_required_context(suites):
             with open("state/suite-%d/url" % i) as f:
                 url = f.read().strip()
         else:
-            # Something went really wrong in the tester. Just link back to the
-            # branch for now, though we should probably just capture the same
-            # text we used to update the commit status.
-            url = ('https://github.com/%s/commits/%s' %
-                   (os.environ['github_repo'], os.environ['github_branch']))
+            # something went really wrong in the tester, just use fallback url
+            url = fallback_url
         result = (suite['rc'] == 0)
         results_suites.append((name, result, url))
 


### PR DESCRIPTION
For the same reasons the 'required' context is useful for branches, it
can also be useful for PRs: it allows repo admins to set a single status
as required in the branch protection settings rather than multiple,
possibly changing, statuses.

This also specifically helps with status-based exemptions in Homu: by
having the required context set on the PR, Homu will be able to
determine whether it can safely skip re-testing the code on the auto
branch.