### PR TITLE
Add docker-autotest for PR testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ file with allowed keys can be found
 
 Projects currently monitored are:
 
+- [autotest/autotest-docker](https://github.com/autotest/autotest-docker.git)
 - [flatpak/flatpak](https://github.com/flatpak/flatpak)
 - [openshift/openshift-ansible](https://github.com/openshift/openshift-ansible)
 - [ostreedev/ostree](https://github.com/ostreedev/ostree)


### PR DESCRIPTION
Our primary supported platforms are all RH-like distros.  Maintaining work-a-like with Travis/Ubuntu is becoming a major headache for otherwise trivial reasons.  Having docker-autotest PRs tested here will allow us to focus more on the code and less on the CI testing environment.