### PR TITLE
Start caching repo metadata and support site repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ LABEL RUN="/usr/bin/docker run --rm --privileged \
              -e os_network \
              -e os_floating_ip_pool \
              -e s3_prefix \
+             -e site_repos \
              -e OS_AUTH_URL \
              -e OS_TENANT_ID \
              -e OS_USERNAME \

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ The following optional environment vars may be set:
   the same OpenStack network as the node.
 - `s3_prefix` -- If specified, artifacts will be uploaded to
   this S3 path, in `<bucket>[/<prefix>]` form.
+- `site_repos` -- If specified, pipe-separated list of
+  repo files to inject. Each entry specifies the OS it is
+  valid for. E.g.:
+
+```
+centos/7=http://example.com/centos.repo|fedora/*=repos/fedora.repo
+```
 
 If you want to support virtualized tests, it also implicitly
 expects the usual OpenStack variables needed for

--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@
 `redhat-ci` is a simple framework currently in use for CI
 testing some Project Atomic repositories. It is similar in
 workflow to Travis CI, but has an emphasis on enabling test
-environments useful for the Project Atomic effort.
+environments useful for the Project Atomic effort. Only
+Fedora and CentOS-based test environments are supported for
+now.
+
+See the full list of projects currently monitored below.
+**If you would like to have a repository added, please open
+a pull request to update the list.**
 
 ### Interacting with redhat-ci
 

--- a/testrunner
+++ b/testrunner
@@ -310,6 +310,44 @@ env_make_rpmmd_cache() {
         envcp "$cachedir/." /var/cache/$mgr
     fi
 
+    if [ -n "${site_repos:-}" ]; then
+        local OLDIFS=$IFS; IFS='|'
+        mkdir -p $state/site-repos
+        for site_repo in $site_repos; do
+            local repo_file=${site_repo#*=}
+            local target_os=${site_repo%=*}
+            local target_os_id=${target_os%/*}
+            local target_os_version_id=${target_os#*/}
+
+            [ -n "$repo_file" ]
+            [ -n "$target_os_id" ]
+            [ -n "$target_os_version_id" ]
+
+            if [ "$target_os_id" != '*' ] &&
+                ([ -z "$os_id" ] ||
+                 [ "$target_os_id" != "$os_id" ]); then
+                    continue
+            fi
+
+            if [ "$target_os_version_id" != '*' ] &&
+                ([ -z "$os_version_id" ] ||
+                 [ "$target_os_version_id" != "$os_version_id" ]); then
+                    continue
+            fi
+
+            if [ "${repo_file::7}" == "http://" ] ||
+               [ "${repo_file::8}" == "https://" ]; then
+                (cd $state/site-repos && curl -LO "$repo_file")
+            else # assume local
+                cp -f $repo_file $state/site-repos
+            fi
+        done
+        IFS=$OLDIFS
+
+        envcmd mkdir -p /etc/yum.repos.d
+        envcp $state/site-repos/. /etc/yum.repos.d
+    fi
+
     # update the cache
     local has_cache=0
     local retries=5

--- a/testrunner
+++ b/testrunner
@@ -125,6 +125,11 @@ prepare_env() {
     echo $upload_dir > $state/upload_dir
     mkdir $upload_dir
 
+    # https://github.com/projectatomic/rpm-ostree/issues/687
+    if ! on_atomic_host; then
+        env_make_rpmmd_cache
+    fi
+
     # inject extra repos before installing packages
     if [ -f $state/parsed/rhci-extras.repo ]; then
         envcmd mkdir -p /etc/yum.repos.d
@@ -200,7 +205,6 @@ ssh_setup_cluster() {
     if container_controlled; then
         # most base images don't have ssh
         if ! envcmd [ -x /bin/ssh ]; then
-            env_make_cache
             envcmd yum install -y openssh-clients
         fi
         envcmd mkdir -m 0600 /root/.ssh
@@ -270,12 +274,10 @@ overlay_packages() {
 install_packages() {
     local upload_dir=$(cat $state/upload_dir)
 
-    mgr=yum
+    local mgr=yum
     if envcmd rpm -q dnf; then
         mgr=dnf
     fi
-
-    env_make_cache
 
     local rc=0
     logged_envcmd $upload_dir/setup.log / - - \
@@ -288,18 +290,67 @@ install_packages() {
     fi
 }
 
-env_make_cache() {
+env_make_rpmmd_cache() {
+    local os_id=$(get_env_os_info ID)
+    local os_version_id=$(get_env_os_info VERSION_ID)
 
-    # This is hacky and sad. Preemptively try to refresh
-    # yum/dnf cache to work around flaky distro infras.
+    local cachedir=
+    if [ -n "$os_id" ] && [ -n "$os_version_id" ]; then
+        cachedir="cache/rpmmd/$os_id/$os_version_id"
+    fi
 
+    local mgr=yum
+    if envcmd rpm -q dnf; then
+        mgr=dnf
+    fi
+
+    # inject cache if we have it
+    if [ -n "$cachedir" ] && [ -d "$cachedir" ]; then
+        envcmd mkdir -p /var/cache/$mgr
+        envcp "$cachedir/." /var/cache/$mgr
+    fi
+
+    # update the cache
+    local has_cache=0
     local retries=5
     while [ $retries -gt 0 ]; do
-        if envcmd yum makecache; then
+        if envcmd $mgr makecache; then
+            has_cache=1
             break
         fi
         retries=$((retries - 1))
     done
+
+    if [ $has_cache == 0 ]; then
+        update_github error "Could not makecache."
+        exit 0
+    fi
+
+    local can_trust_cache=0
+    if host_controlled; then
+        can_trust_cache=1 # we trust all the distros we offer ourselves
+    else
+        # only trust official containers
+        local image=$(cat $state/parsed/image)
+        if grep -q -E '^registry.fedoraproject.org' <<< "$image" ||
+           grep -q -E '^(fedora|centos)(:[[:alnum:]_.-]+)?$' <<< "$image"; then
+            can_trust_cache=1
+        fi
+    fi
+
+    # update our own cache with the updated cache
+    if [ -n "$cachedir" ] && [ $can_trust_cache == 1 ]; then
+        mkdir -p "$cachedir"
+        envfetch /var/cache/$mgr/. "$cachedir"
+
+        # but only keep non-system solvs & repodata
+        # NB: yum only keeps repo metadata there, so no need to prune
+        if [ $mgr == dnf ]; then
+            find "$cachedir" -maxdepth 1 \
+                ! -type d ! -name '*.solv' ! -name '*.solvx' -delete
+            rm -f "$cachedir/@System.solv"
+        fi
+    fi
 }
 
 run_loop() {
@@ -401,6 +452,11 @@ fetch_artifacts() {
             while IFS='' read -r artifact || [[ -n $artifact ]]; do
                 path="/var/tmp/checkout/$artifact"
                 if vmssh [ -e "$path" ]; then
+                    # NB: We could use rsync here to be more efficient, though
+                    # we need the --ignore-missing-args switch, which is not
+                    # available on older platforms. Anyway, in this case, we're
+                    # always fetching from scratch and the test envs are not
+                    # far, so scp shouldn't be much slower.
                     vmscp -r "root@$node_addr:$path" $upload_dir/artifacts
                     fetched_at_least_one=1
                 fi
@@ -617,6 +673,24 @@ envcp() {
     fi
 }
 
+envfetch() {
+    remote=$1; shift
+    target=$1; shift
+
+    if container_controlled; then
+        local cid=$(cat $state/cid)
+        sudo docker cp $cid:$remote $target
+    else
+        local node_addr=$(cat $state/host/node_addr)
+        rsync --quiet -az --no-owner --no-group \
+            -e "ssh -q -i $state/node_key \
+                       -o StrictHostKeyChecking=no \
+                       -o PasswordAuthentication=no \
+                       -o UserKnownHostsFile=/dev/null" \
+            root@$node_addr:$remote $target
+    fi
+}
+
 vmssh() {
     # NB: we use -n because stdin may be in use (e.g. in a
     # bash while read loop)
@@ -734,6 +808,10 @@ host_controlled() {
 
 on_atomic_host() {
     host_controlled && vmssh test -f /run/ostree-booted
+}
+
+get_env_os_info() {
+    (. <(envcmd cat /etc/os-release) && echo ${!1} || :)
 }
 
 main "$@"


### PR DESCRIPTION
See commit messages for more info.

All in all, it's a pretty nice speedup. For example, downloading the Fedora's `fedora` and `updates` repos and creating their solvs takes about 30s on average (assuming we hit a fast mirror, which is not always the case). This is completely eliminated with caching. Combined with the ability to override the repos with closer mirrors, I see provisioning sometimes take less than half what they used to for a simple install of e.g. `@buildsys-build`.

Of course, installation time takes longer than downloading time, so the relative effect is not as drastic for suites that download many packages. For that, projects can use prebuilt containers, or once we support building RPMs, we'll rely on cached buildroots. Though this is a good first step to optimize the common case and lessen traffic load.