### PR TITLE
papr: hook papr to papr

### DIFF
--- a/.papr.yaml
+++ b/.papr.yaml
@@ -1,0 +1,13 @@
+branches:
+  - master
+  - auto
+  - try
+
+required: true
+
+container:
+    image: registry.fedoraproject.org/fedora:25
+
+tests:
+    - pip3 install flake8
+    - flake8 *.py utils/*.py

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ please see [RUNNING](RUNNING.md).
 - [projectatomic/commissaire-service](https://github.com/projectatomic/commissaire-service)
 - [projectatomic/container-storage-setup](https://github.com/projectatomic/container-storage-setup)
 - [projectatomic/docker](https://github.com/projectatomic/docker)
+- [projectatomic/papr](https://github.com/projectatomic/papr)
 - [projectatomic/registries](https://github.com/projectatomic/registries)
 - [projectatomic/rpm-ostree](https://github.com/projectatomic/rpm-ostree)
 


### PR DESCRIPTION
So that we have more PAPR in our PAPR.

This is just running flake8 for now, because I want to hook up homu to
this repo.

This is a start for https://github.com/projectatomic/papr/issues/43.