### PR TITLE
testrunner: safer error handling

### DIFF
--- a/testrunner
+++ b/testrunner
@@ -808,9 +808,12 @@ ensure_err_github_update() {
 }
 
 teardown_node() {
-    teardown_node_impl \
-        $(cat $state/host/node_name) \
-        $(cat $state/host/node_addr)
+    if [ -f $state/host/node_name ] && \
+       [ -f $state/host/node_addr ]; then
+        teardown_node_impl \
+            $(cat $state/host/node_name) \
+            $(cat $state/host/node_addr)
+    fi
 }
 
 teardown_node_impl() {
@@ -849,15 +852,20 @@ ensure_teardown_container() {
 }
 
 teardown_cluster() {
-    local nhosts=$(cat $state/parsed/nhosts)
+    if [ -f $state/parsed/nhosts ]; then
+        local nhosts=$(cat $state/parsed/nhosts)
 
-    local i=0
-    while [ $i -lt $nhosts ]; do
-        teardown_node_impl \
-            $(cat $state/host-$i/node_name) \
-            $(cat $state/host-$i/node_addr)
-        i=$((i + 1))
-    done
+        local i=0
+        while [ $i -lt $nhosts ]; do
+            if [ -f $state/host-$i/node_name ] && \
+               [ -f $state/host-$i/node_addr ]; then
+                teardown_node_impl \
+                    $(cat $state/host-$i/node_name) \
+                    $(cat $state/host-$i/node_addr)
+            fi
+            i=$((i + 1))
+        done
+    fi
 
     if container_controlled; then
         teardown_container

--- a/utils/gh.py
+++ b/utils/gh.py
@@ -95,18 +95,18 @@ def _update_status(repo, commit, token, data):
                (repo, commit))
 
     if __name__ == '__main__':
-        print("Updating status of commit", commit, "with data", data)
+        eprint("Updating status of commit", commit, "with data", data)
 
     try:
         # use data= instead of json= in case we're running on an older requests
         resp = requests.post(api_url, data=json.dumps(data), headers=header)
         body = resp.json()
     except JSONDecodeError:
-        print("Expected JSON, but received:")
-        print("---")
-        print(resp.content)
-        print("---")
-        print("Retrying...")
+        eprint("Expected JSON, but received:")
+        eprint("---")
+        eprint(resp.content)
+        eprint("---")
+        eprint("Retrying...")
         resp = requests.post(api_url, data=json.dumps(data), headers=header)
         body = resp.json()
 
@@ -146,6 +146,10 @@ def comment(repo, token, issue, text):
         if body is not None:
             errmsg += "\n" + str(body)
         raise Exception(errmsg)
+
+
+def eprint(*args):
+    print(*args, file=sys.stderr)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I was reading the cleanup logs when we encounter failing infra and found
out that we're still trying to tear down nodes even when they weren't
even provisioned at all. The core of the issue is that
`x=$(cat /non/existent)` will not trigger `errexit`, so we have to
explicitly check for the file beforehand. Accomodating these shell
gotchas is a short term solution until we absorb all the logic into the
Python bits.

Also make sure that the gh module writes its diagnostics to stderr
rather than stdout.