### PR TITLE
DISTROS.md: drop fedora/24/cloud and update fedora/26/atomic

### DIFF
--- a/DISTROS.md
+++ b/DISTROS.md
@@ -3,10 +3,10 @@
 Below is a full list of valid values for the `distro` key in
 the YAML:
 
-- `fedora/24/cloud`
 - `fedora/25/atomic`
 - `fedora/25/cloud`
 - `fedora/26/atomic`
+- `fedora/26/atomic/pungi`
 - `centos/7/atomic`
 - `centos/7/cloud`
 - `centos/7/atomic/alpha`
@@ -23,14 +23,25 @@ update them.
 
 ## Fedora streams:
 
-### fedora/25/atomic
+### fedora/26/atomic
 
-This is the officially supported Atomic image from Fedora.
-They are usuall updated
+This is the officially supported Atomic Host image from
+Fedora. They are usually updated
 [every two
 weeks](https://fedoraproject.org/wiki/Changes/Two_Week_Atomic).
 You can download the image yourself from
 https://getfedora.org/en/atomic/download/.
+
+### fedora/26/atomic/pungi
+
+These are fetched from koji after the (currently daily) runs
+of [pungi](https://pagure.io/pungi).
+
+### fedora/25/atomic
+
+This is the last officially released Fedora 25 Atomic Host
+image, which is no longer updated. It will be removed once
+projects have migrated to Fedora 26.
 
 ### fedora/24/cloud, fedora/25/cloud
 
@@ -38,13 +49,6 @@ These are the officially supported Cloud images from Fedora.
 They are not usually updated after initial release. You can
 download the image yourself from
 https://alt.fedoraproject.org/en/cloud/.
-
-### fedora/26/atomic
-
-These are pre-release versions of Fedora 26 Atomic Host.
-They are fetched from koji following each
-[pungi](https://pagure.io/pungi) compose. Once Fedora 26 is
-released, this stream will track the two week releases.
 
 ## CentOS streams:
 


### PR DESCRIPTION
I don't think anyone is using `fedora/24/cloud` anymore, so let's not
support it anymore.

Also update the description for `fedora/26/atomic` since it's now been
released and add the `fedora/26/atomic/pungi` stream which replaces it.