### PR TITLE
provisioner: hotfix for MTU mismatch in OSP

### DIFF
--- a/papr/provisioner
+++ b/papr/provisioner
@@ -52,6 +52,16 @@ provision_host() {
         fi
         deploy_ostree
     fi
+
+    # XXX: add hotfix for https://bugzilla.redhat.com/show_bug.cgi?id=1475460
+    # XXX: this is hacky and just a bad spot for doing this, but really everyone
+    # provisioning F26 is going to hit this, so might as well include it here
+    # rather than require all projects to have a workaround
+    if [[ $os_image == fedora/26/* ]]; then
+        vmssh sed -i '/^DOCKER_NETWORK_OPTIONS=/ s/$/--mtu 1400/' \
+            /etc/sysconfig/docker-network
+        vmssh systemctl restart docker
+    fi
 }
 
 deploy_ostree() {


### PR DESCRIPTION
Just bolt on a temporary hotfix here for
https://bugzilla.redhat.com/show_bug.cgi?id=1475460.

In a nutshell: the MTU mismatch between the docker devices and the
default route is causing some connections to internal sites to hang (or
sometimes work, but with severely degraded performance).

Quoting the comment in the diff:

    # XXX: this is hacky and just a bad spot for doing this, but really everyone
    # provisioning F26 is going to hit this, so might as well include it here
    # rather than require all projects to have a workaround