### PR TITLE
parser: also handle yaml.parser.ParserError

### DIFF
--- a/.papr.yaml
+++ b/.papr.yaml
@@ -8,11 +8,16 @@ required: true
 container:
     image: registry.fedoraproject.org/fedora:25
 
-packages:
-    - '@buildsys-build'
-    - python3-devel
+# temp workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1483553
+#packages:
+#    - '@buildsys-build'
+#    - python3-devel
 
 tests:
+    # temp workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1483553
+    - if (dnf upgrade -y || :) |& grep -q -e BDB1539; then
+      rpm --rebuilddb; dnf upgrade -y;
+      fi; dnf install -y python3-devel '@buildsys-build'
     - pip3 install flake8 pylint -r requirements.txt
     - flake8 *.py papr/*.py papr/utils/*.py
     - pylint -E *.py papr

--- a/papr/utils/parser.py
+++ b/papr/utils/parser.py
@@ -43,7 +43,7 @@ class SuiteParser:
         # catch exceptions due to a bad YAML and transform into ParserError
         except UnicodeDecodeError:
             raise ParserError("file is not valid UTF-8")
-        except yaml.scanner.ScannerError as e:
+        except (yaml.scanner.ScannerError, yaml.parser.ParserError):
             raise ParserError("file could not be parsed as valid YAML")
 
     def parse(self):


### PR DESCRIPTION
If PyYAML fails to parse the YAML, let's not crash.
This happened in https://github.com/ostreedev/ostree/pull/1160.