### PR TITLE
os provisioning: use volumes for secondary disk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ LABEL RUN="/usr/bin/docker run --rm --privileged \
              -e site_repos \
              -e OS_AUTH_URL \
              -e OS_TENANT_ID \
+             -e OS_TENANT_NAME \
              -e OS_USERNAME \
              -e OS_PASSWORD \
              -e AWS_ACCESS_KEY_ID \

--- a/papr/provisioner
+++ b/papr/provisioner
@@ -27,7 +27,7 @@ provision_host() {
     # include the BUILD_ID directly in the name to make it
     # easier to determine which nodes belong to which runs
     # when troubleshooting
-    os_name_prefix=github-ci-testnode
+    os_name_prefix=papr
     if [ -n "${BUILD_ID:-}" ]; then
         os_name_prefix=$os_name_prefix-$BUILD_ID
     fi

--- a/papr/testrunner
+++ b/papr/testrunner
@@ -68,7 +68,12 @@ provision_container() {
         exit 0
     fi
 
-    sudo docker run -d \
+    local name=papr-$(date +%s%N)
+    if [ -n "${BUILD_ID:-}" ]; then
+        name=$name-$BUILD_ID
+    fi
+
+    sudo docker run --name $name -d \
         --cidfile $state/cid \
         "$image" sleep infinity
 

--- a/papr/testrunner
+++ b/papr/testrunner
@@ -817,16 +817,23 @@ teardown_node() {
        [ -f $state/host/node_addr ]; then
         teardown_node_impl \
             $(cat $state/host/node_name) \
-            $(cat $state/host/node_addr)
+            $(cat $state/host/node_addr) \
+            $(cat $state/host/node_volid)
     fi
 }
 
 teardown_node_impl() {
     local node_name=$1; shift
     local node_addr=$1; shift
+    local node_volid=$1; shift
 
     if [ -z "$node_name" ]; then
         return
+    fi
+
+    if [ -n "$node_volid" ]; then
+        nova volume-detach $node_name $node_volid
+        cinder --os-volume-api-version=2 delete $node_volid
     fi
 
     if [ -n "$node_addr" ] && \
@@ -866,7 +873,8 @@ teardown_cluster() {
                [ -f $state/host-$i/node_addr ]; then
                 teardown_node_impl \
                     $(cat $state/host-$i/node_name) \
-                    $(cat $state/host-$i/node_addr)
+                    $(cat $state/host-$i/node_addr) \
+                    $(cat $state/host-$i/node_volid)
             fi
             i=$((i + 1))
         done

--- a/papr/utils/os_provision.py
+++ b/papr/utils/os_provision.py
@@ -111,9 +111,11 @@ server = nova.servers.create(name, meta=meta, image=image, userdata=userdata,
                              nics=[{'net-id': network.id}])
 print("INFO: booted server %s (%s)" % (name, server.id))
 
+
 def write_to_file(fn, s):
     with open(os.path.join(output_dir, fn), 'w') as f:
         f.write(s)
+
 
 write_to_file('node_name', name)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # we're not compatible with the latest nova API
 python-novaclient==7.1.0
+python-cinderclient==3.2.0
 PyYAML==3.12
 jinja2==2.9.6
 awscli==1.11.72


### PR DESCRIPTION
The new OpenStack instance doesn't support flavors with ephemeral disks.
Rather, they encourage users to provision Cinder volumes. We teach our
provisioner to do this in this patch. This is required to support
projects like atomic and container-storage-setup which want a secondary
disk for testing.

I didn't bother cleaning up the code much. A lot of this is already
structured much more nicely in the Python rewrite and I didn't want to
duplicate more work than necessary.