### PR TITLE
spec: use fedora/26/atomic as an example

### DIFF
--- a/docs/sample.papr.yml
+++ b/docs/sample.papr.yml
@@ -9,7 +9,7 @@
 host:
     # REQUIRED
     # Specify the distro to provision (see DISTROS.md for full list).
-    distro: fedora/25/atomic
+    distro: fedora/26/atomic
 
     # OPTIONAL
     # Specify the minimum requirements the host must


### PR DESCRIPTION
Because `fedora/25/atomic` is sooo 6 months ago.

Really, I'm just using this as an excuse to test status-based
exemptions, for which I'm unreasonably excited about.