### PR TITLE
provisioner: still sort flavors by ephemeral size

### DIFF
--- a/papr/utils/os_provision.py
+++ b/papr/utils/os_provision.py
@@ -69,6 +69,7 @@ def filter_flavors(flavors, attr):
 flavors = filter_flavors(flavors, 'vcpus')
 flavors = filter_flavors(flavors, 'ram')
 flavors = filter_flavors(flavors, 'disk')
+flavors = filter_flavors(flavors, 'ephemeral')
 
 flavor = flavors[0]
 print("INFO: choosing flavor '%s'" % flavor.name)


### PR DESCRIPTION
This is a minor correction from #61. We no longer need a flavor to have
an ephemeral disk. But when selecting the best flavor from the set of
flavors that match our criteria, we do still want to minimize it
(preferably selecting a flavor that has none at all if possible).

These "disks" appear as pre-formatted block devices which get
auto-mounted on `/var/tmp` (at least on `fedora/26/atomic`). This was
causing atomic-host-tests to fail since it gets the `unlabeled_t` label.

This won't matter soon anyway once we move to an OpenStack instance
which doesn't have any flavors with ephemeral disks. Though the patch is
still valid.