### PR TITLE
os_provision.py: appease the latest flake8

### DIFF
--- a/papr/utils/os_provision.py
+++ b/papr/utils/os_provision.py
@@ -160,7 +160,7 @@ if min_ephemeral > 0:
 
         # now we can safely attach the volume
         nova.volumes.create_server_volume(server.id, vol.id)
-    except:
+    except Exception:
         server.delete()
         if vol is not None:
             vol.delete()


### PR DESCRIPTION
The latest flake8 doesn't like "naked except" clauses. Since we don't
fix it to a specific version, I was surprised that didn't happen sooner.
Let's just please it so we can use Homu for merges.