### PR TITLE
DISTROS.md: add centos/7/atomic/smoketested and drop alpha

### DIFF
--- a/docs/DISTROS.md
+++ b/docs/DISTROS.md
@@ -10,7 +10,7 @@ the YAML:
 - `fedora/27/cloud`
 - `centos/7/atomic`
 - `centos/7/cloud`
-- `centos/7/atomic/alpha`
+- `centos/7/atomic/smoketested`
 - `centos/7/atomic/continuous`
 
 It follows a consistent pattern:
@@ -68,7 +68,7 @@ updated every 2 to 6 weeks after RHEL releases. You can
 download the image yourself from
 https://wiki.centos.org/Download.
 
-### centos/7/atomic/alpha, centos/7/atomic/continuous
+### centos/7/atomic/smoketested, centos/7/atomic/continuous
 
 These images are built much more frequently and closely
 track the master branch of the git repositories of many core


### PR DESCRIPTION
Remove the `/alpha` images as they are no longer maintained. Add the new
`/smoketested` images. I preferred to keep these names distinct, rather
than making `/alpha` actually be the smoketested images to actually
reflect the status upstream. For more details, see:

https://github.com/CentOS/sig-atomic-buildscripts/issues/269
https://github.com/CentOS/sig-atomic-buildscripts/pull/293
https://github.com/CentOS/sig-atomic-buildscripts/pull/309