### PR TITLE
testrunner: add support for PAPR_PULL_TARGET_BRANCH

### DIFF
--- a/papr/testrunner
+++ b/papr/testrunner
@@ -190,6 +190,8 @@ prepare_env() {
         if [ -f state/is_merge_sha ]; then
             echo "export PAPR_MERGE_COMMIT=$(cat state/sha)" >> $state/parsed/envs
         fi
+        local target_branch=$(query_github pulls/${github_pull_id} base ref)
+        echo "export PAPR_PULL_TARGET_BRANCH=${target_branch}" >> $state/parsed/envs
     fi
 }
 

--- a/papr/utils/common.sh
+++ b/papr/utils/common.sh
@@ -97,3 +97,23 @@ ssh_wait() {
         return 1
     fi
 }
+
+# Generic query to the GitHub API
+# $1    resource
+# $2..  path to key to print
+query_github() {
+    resource=$1; shift
+    python3 -c "
+import sys
+import requests
+header = {'Authorization': 'token ${github_token}'}
+d = requests.get('https://api.github.com/repos/${github_repo}/$resource', headers=header)
+if (d.status_code != requests.codes.ok):
+    raise Exception('API Error: {}'.format(d.content))
+j = d.json()
+for q in sys.argv[1:]:
+    if q.isdigit():
+        q = int(q)
+    j = j[q]
+print(j)" "$@"
+}


### PR DESCRIPTION
It can be useful for pull request tests to know which branch they're
targeted at. E.g. openshift-ansible for example can make use of this in
order to match the version of origin to use.

Tests could have used the API themselves anonymously before this, though
given that the rate limit is 60 requests per hour per IP, that's not
really scalable. So let's just make the request ourselves and pass down
that information.