### PR TITLE
testrunner: pass through /dev/kvm to containers

### DIFF
--- a/papr/testrunner
+++ b/papr/testrunner
@@ -74,6 +74,7 @@ provision_container() {
     fi
 
     sudo docker run --name $name -d \
+        --device /dev/kvm \
         --cidfile $state/cid \
         "$image" sleep infinity
 


### PR DESCRIPTION
For reasons I can't quite figure out, `oci-kvm-hook` doesn't work on F25
(though it does on F27). The nodes are currently stuck at F25 because of
severe issues with `docker cp` in newer version (rhbz#1489505). So let's
just explicitly pass /dev/kvm into the container, which is all
`oci-kvm-hook` is trying to do anyway. I've verified this works.

This will unblock https://github.com/ostreedev/ostree/pull/1462.