### PR TITLE
templates: add more details to index pages

### DIFF
--- a/papr/main
+++ b/papr/main
@@ -86,6 +86,7 @@ checkout_ref() {
     if [ -n "${github_branch:-}" ]; then
         git -C $repo fetch origin $github_branch
         sha_cmp=$(git -C $repo rev-parse FETCH_HEAD)
+        export github_url=https://github.com/$github_repo/commits/$github_branch
     else
         if git -C $repo fetch origin refs/pull/$github_pull_id/merge; then
             touch state/is_merge_sha
@@ -94,6 +95,7 @@ checkout_ref() {
             git -C $repo fetch origin refs/pull/$github_pull_id/head
             sha_cmp=$(git -C $repo rev-parse FETCH_HEAD)
         fi
+        export github_url=https://github.com/$github_repo/pull/$github_pull_id
     fi
 
     if [ -n "${github_commit:-}" ] && [ "$github_commit" != "$sha_cmp" ]; then

--- a/papr/testrunner
+++ b/papr/testrunner
@@ -584,7 +584,8 @@ s3_upload() {
 
     if [ $s3_object = index.html ]; then
         # don't change directory in current session
-        ( cd $upload_dir && python3 $indexer )
+        local context=$(cat $state/parsed/context)
+        ( cd $upload_dir && github_context="$context" python3 $indexer )
     fi
 
     # only actually upload if we're given $s3_prefix
@@ -653,19 +654,16 @@ logged_envcmd() {
     if [ ! -f $logfile ]; then
 
         echo "### $(date --utc)" > $logfile
+        echo "### $github_url" >> $logfile
+        echo "### $github_commit" >> $logfile
 
-        if [ -n "${github_branch:-}" ]; then
-            echo "### Branch $github_branch" >> $logfile
-        else
-            echo -n "### PR #$github_pull_id" >> $logfile
-            # NB: is_merge_sha is in the top-level global state dir
-            if [ ! -f state/is_merge_sha ]; then
-                echo " (WARNING: not merge sha, check for conflicts)" \
-                    >> $logfile
-            else
-                echo >> $logfile
-            fi
+        # NB: is_merge_sha is in the top-level global state dir
+        if [ -n "${github_pull_id:-}" ] && [ ! -f state/is_merge_sha ]; then
+            echo "### (WARNING: not merge sha, check for conflicts)" >> $logfile
         fi
+
+        local context=$(cat $state/parsed/context)
+        echo "### TESTSUITE $context" >> $logfile
 
         if [ -n "${BUILD_ID:-}" ]; then
             echo "### BUILD_ID $BUILD_ID" >> $logfile

--- a/papr/utils/index.j2
+++ b/papr/utils/index.j2
@@ -3,6 +3,8 @@
     <title>Listing</title>
   </head>
 <body>
+  <a href="{{ url }}">{{ url }}</a> ({{ commit[:7] }})<br>
+  Testsuite: <b>{{ context }}</b><br><br>
 {% if files|length > 1 %}
   {{ files|length }} entries
 {% else %}

--- a/papr/utils/required-index.j2
+++ b/papr/utils/required-index.j2
@@ -3,6 +3,7 @@
     <title>Test results</title>
   </head>
 <body>
+  <a href="{{ url }}">{{ url }}</a> ({{ commit[:7] }})<br><br>
   Test results
   <ul>
 {% for name, passed, link in suites -%}


### PR DESCRIPTION
It's annoying to be linked to a results page and not easily know from
which repo/PR/branch test it came from. Let's just plop those details
directly into the pages we generate.