### PR TITLE
utils/common: wait longer before SSH comes up

### DIFF
--- a/papr/utils/common.sh
+++ b/papr/utils/common.sh
@@ -59,7 +59,7 @@ ssh_wait() {
     local node_addr=$1; shift
     local node_key=$1; shift
 
-    timeout 120s "$THIS_DIR/utils/sshwait" $node_addr
+    timeout 210s "$THIS_DIR/utils/sshwait" $node_addr
 
     # We have to be extra cautious here -- OpenStack
     # networking takes some time to settle, so we wait until


### PR DESCRIPTION
In kernel release 4.16.4, there was a change to how `/dev/random` is
handled at boot time. This is causing much longer startup times than
before. There's an issue open to track this[1], but in the meantime,
let's do something no one likes to do and increase our timeout before
deeming a node broken.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1572944