### PR TITLE
testrunner: bump max file size to 5M

### DIFF
--- a/papr/testrunner
+++ b/papr/testrunner
@@ -584,9 +584,9 @@ s3_upload() {
 
     # go through every file we'll upload and make sure it's no more than the max
     # size, otherwise violently truncate it
-    find $upload_dir -mindepth 1 -size +3M | while read f; do
+    find $upload_dir -mindepth 1 -size +5M | while read f; do
         local orig_size=$(stat -c %s "$f")
-        truncate -s 3M "$f"
+        truncate -s 5M "$f"
         echo -e "\n### FILE TRUNCATED (ORIGINAL SIZE: $orig_size)" >> "$f"
     done
 


### PR DESCRIPTION
Logs from openshift-ansible runs genuinely need more space, so let's
bump it up a bit.