### PR TITLE
os_provision: add support for a flavor prefix

### DIFF
--- a/.papr.yaml
+++ b/.papr.yaml
@@ -6,7 +6,7 @@ branches:
 required: true
 
 container:
-    image: registry.fedoraproject.org/fedora:27
+    image: registry.fedoraproject.org/fedora:30
 
 packages:
     - '@buildsys-build'

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ LABEL RUN="/usr/bin/docker run --rm --privileged \
              -e os_keyname \
              -e os_privkey \
              -e os_network \
+             -e os_flavor_prefix \
              -e s3_prefix \
              -e site_repos \
              -e OS_AUTH_URL \

--- a/docs/RUNNING.md
+++ b/docs/RUNNING.md
@@ -24,6 +24,7 @@ The following optional environment vars may be set:
   keyname, if you want to support virtualized tests.
 - `os_network` -- OpenStack network to use for provisioning,
   if you want to support virtualized tests.
+- `os_flavor_prefix` -- Prefix candidate flavors must have.
 - `os_floating_ip_pool` -- If specified, assign a floating
   IP to the provisioned node from this pool and use the IP
   to communicate with it. This is required if not running on

--- a/papr/utils/os_provision.py
+++ b/papr/utils/os_provision.py
@@ -17,6 +17,7 @@
       - os_name_prefix
       - os_keyname
       - os_min_ephemeral
+      - os_flavor_prefix
 '''
 
 import os
@@ -62,6 +63,8 @@ def get_image(name):
 print("INFO: resolving image '%s'" % os.environ['os_image'])
 image = get_image(os.environ['os_image'])
 
+flavor_prefix = os.environ.get('os_flavor_prefix', '')
+
 # go through all the flavours and determine which one to use
 min_ram = int(os.environ['os_min_ram'])
 min_vcpus = int(os.environ['os_min_vcpus'])
@@ -69,7 +72,8 @@ min_disk = int(os.environ['os_min_disk'])
 flavors = nova.flavors.list()
 flavors = [f for f in flavors if (f.ram >= min_ram and
                                   f.vcpus >= min_vcpus and
-                                  f.disk >= min_disk)]
+                                  f.disk >= min_disk and
+                                  f.name.startswith(flavor_prefix))]
 
 if len(flavors) == 0:
     print("ERROR: no flavor satisfies minimum requirements.")


### PR DESCRIPTION
There is a requirement on the internal OpenStack instance to only use
flavors prefixed with `ci.`.

To enable this, add a new `os_flavor_prefix` env var which the
provisioner picks up on and uses to filter down the list of candidate
flavors.