### PR TITLE
Remove conmon and libpod

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ please see [RUNNING](docs/RUNNING.md).
 ### Monitored projects
 
 - [autotest/autotest-docker](https://github.com/autotest/autotest-docker.git)
-- [containers/conmon](https://github.com/containers/conmon)
-- [containers/libpod](https://github.com/containers/libpod)
 - [flatpak/flatpak](https://github.com/flatpak/flatpak)
 - [flatpak/flatpak-builder](https://github.com/flatpak/flatpak-builder)
 - [openshift/openshift-ansible](https://github.com/openshift/openshift-ansible)


### PR DESCRIPTION
removing the containers/libpod|conmon from redhat-ci

Signed-off-by: baude <bbaude@redhat.com>